### PR TITLE
Remove check that each entry is a fully resolved library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,11 +121,6 @@ if (enable_parmetislib)   ## want to use parmetis
   if (NOT TPL_PARMETIS_LIBRARIES)
     message(FATAL_ERROR "TPL_PARMETIS_LIBRARIES option should be set for PARMETIS support to be enabled.")
   endif()
-  foreach(lib ${TPL_PARMETIS_LIBRARIES})
-    if (NOT EXISTS ${lib})
-      message(FATAL_ERROR "PARMETIS library not found: ${lib}")
-    endif()
-  endforeach()
 
   if (NOT TPL_PARMETIS_INCLUDE_DIRS)
     message(FATAL_ERROR "TPL_PARMETIS_INCLUDE_DIRS option be set for PARMETIS support to be enabled.")


### PR DESCRIPTION
this makes it impossible to pass in complicated constructs with rpath etc that
will be automatically generated by other packages for the libraries

Funded-by: IDEAS
Project: xSDK
Time: .3 hours