### PR TITLE
uadd _LONGINT to superlu_dist_config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ option(TPL_PARMETIS_INCLUDE_DIRS "List of absolute paths to ParMETIS include dir
 # set(CMAKE_C_FLAGS "-DDEBUGlevel=0 -DPRNTlevel=0 ${CMAKE_C_FLAGS}")
 if(XSDK_INDEX_SIZE EQUAL 64)
     message("-- Using 64 bit integer for index size")
-    set(CMAKE_C_FLAGS "-D_LONGINT ${CMAKE_C_FLAGS}")
 endif()	
 set(CMAKE_C_FLAGS_RELEASE "-O3" CACHE STRING "")
 
@@ -223,6 +222,7 @@ endif()
 # file(WRITE "make.defs" "# can be exposed to users" ${CMAKE_C_COMPILER})
 # configure_file(${CMAKE_SOURCE_DIR}/make.inc.in ${CMAKE_BINARY_DIR}/make.inc)
 configure_file(${SuperLU_DIST_SOURCE_DIR}/make.inc.in ${SuperLU_DIST_SOURCE_DIR}/make.inc)
+configure_file(${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h.in ${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h)
 
 # Add pkg-config support
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu_dist.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu_dist.pc @ONLY)

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -9,6 +9,7 @@ set(headers
     supermatrix.h
     util_dist.h
     colamd.h
+    superlu_dist_config.h
 )
 
 # first: precision-independent files

--- a/SRC/superlu_defs.h
+++ b/SRC/superlu_defs.h
@@ -66,6 +66,7 @@ at the top-level directory.
 #define SUPERLU_DIST_MINOR_VERSION     2
 #define SUPERLU_DIST_PATCH_VERSION     0
 
+#include "superlu_dist_config.h"
 /* Define my integer size int_t */
 #ifdef _CRAY
   typedef short int_t;

--- a/SRC/superlu_dist_config.h.in
+++ b/SRC/superlu_dist_config.h.in
@@ -1,0 +1,9 @@
+/* superlu_dist_config.h.in */
+
+/* enable 64bit index mode */
+#cmakedefine XSDK_INDEX_SIZE @XSDK_INDEX_SIZE@
+
+#if (XSDK_INDEX_SIZE == 64)
+#define _LONGINT 1
+#endif
+


### PR DESCRIPTION
Currently -D_LONGINT is set required to be set via CFLAGS during build. And when user code uses such a build - they should know this fact and set this flag all the time - otherwise there could be type mismatch.

Its best to save such config differences within superlu_dist include files - so that the build type (regular vs _LONGINT) can easily be discovered (from any given superlu_dist install) and used correctly.

This PR includes my attempt to create superlu_dist_config.h that sets  this flag _LONGINT - when needed - without modifying the current CMAKE interface flag -DXSDK_INDEX_SIZE=64

@BarrySmith @xiaoyeli