### PR TITLE
Add CMake scipts to find ParMETIS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(VERSION_MINOR "2")
 set(VERSION_BugFix "2")
 set(PROJECT_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BugFix})
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
 ######################################################################
 #
 # IDEAS: xSDK standards module
@@ -181,9 +183,13 @@ else()
   message("-- Will not link with ParMETIS.")
 endif()
 
-# if(NOT enable_parmetislib)
-#  find_package(PARMETIS)    ## does not have this Module yet.
-# endif()
+if(NOT enable_parmetislib)
+  find_package(ParMETIS)
+  if(PARMETIS_FOUND)
+    set(PARMETIS_LIB ParMETIS::ParMETIS)
+    set(TPL_PARMETIS_INCLUDE_DIRS "")
+  endif()
+endif()
 
 
 ######################################################################

--- a/cmake/FindMETIS.cmake
+++ b/cmake/FindMETIS.cmake
@@ -1,0 +1,54 @@
+# - Try to find METIS
+# Once done this will define
+#
+#  METIS_FOUND        - system has METIS
+#  METIS_INCLUDE_DIRS - include directories for METIS
+#  METIS_LIBRARIES    - libraries for METIS
+#
+# and the imported target
+#
+#  METIS::METIS
+
+find_path(METIS_INCLUDE_DIR metis.h
+  DOC "Directory where the METIS header files are located"
+)
+mark_as_advanced(METIS_INCLUDE_DIR)
+set(METIS_INCLUDE_DIRS "${METIS_INCLUDE_DIR}")
+
+find_library(METIS_LIBRARY
+  NAMES metis
+  DOC "Directory where the METIS library is located"
+)
+mark_as_advanced(METIS_LIBRARY)
+set(METIS_LIBRARIES "${METIS_LIBRARY}")
+
+# Get METIS version
+if(NOT METIS_VERSION_STRING AND METIS_INCLUDE_DIR AND EXISTS "${METIS_INCLUDE_DIR}/metis.h")
+  set(version_pattern "^#define[\t ]+METIS_(MAJOR|MINOR)_VERSION[\t ]+([0-9\\.]+)$")
+  file(STRINGS "${METIS_INCLUDE_DIR}/metis.h" metis_version REGEX ${version_pattern})
+
+  foreach(match ${metis_version})
+    if(METIS_VERSION_STRING)
+      set(METIS_VERSION_STRING "${METIS_VERSION_STRING}.")
+    endif()
+    string(REGEX REPLACE ${version_pattern} "${METIS_VERSION_STRING}\\2" METIS_VERSION_STRING ${match})
+    set(METIS_VERSION_${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
+  endforeach()
+  unset(metis_version)
+  unset(version_pattern)
+endif()
+
+# Standard package handling
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(METIS
+  REQUIRED_VARS METIS_LIBRARY METIS_INCLUDE_DIR
+  VERSION_VAR METIS_VERSION_STRING
+)
+
+if(METIS_FOUND)
+  if(NOT TARGET METIS::METIS)
+    add_library(METIS::METIS UNKNOWN IMPORTED)
+  endif()
+  set_property(TARGET METIS::METIS PROPERTY IMPORTED_LOCATION "${METIS_LIBRARY}")
+  set_property(TARGET METIS::METIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIRS}")
+endif()

--- a/cmake/FindParMETIS.cmake
+++ b/cmake/FindParMETIS.cmake
@@ -1,0 +1,60 @@
+# - Try to find ParMETIS
+# Once done this will define
+#
+#  PARMETIS_FOUND        - system has ParMETIS
+#  PARMETIS_INCLUDE_DIRS - include directories for ParMETIS
+#  PARMETIS_LIBRARIES    - libraries for ParMETIS
+#
+# and the imported target
+#
+#  ParMETIS::ParMETIS
+
+find_path(ParMETIS_INCLUDE_DIR parmetis.h
+  DOC "Directory where the ParMETIS header files are located"
+)
+mark_as_advanced(ParMETIS_INCLUDE_DIR)
+set(ParMETIS_INCLUDE_DIRS "${ParMETIS_INCLUDE_DIR}")
+
+find_library(ParMETIS_LIBRARY
+  NAMES parmetis
+  DOC "Directory where the ParMETIS library is located"
+)
+mark_as_advanced(ParMETIS_LIBRARY)
+set(ParMETIS_LIBRARIES "${ParMETIS_LIBRARY}")
+
+# Get ParMETIS version
+if(NOT PARMETIS_VERSION_STRING AND PARMETIS_INCLUDE_DIR AND EXISTS "${PARMETIS_INCLUDE_DIR}/parmetis.h")
+  set(version_pattern "^#define[\t ]+PARMETIS_(MAJOR|MINOR)_VERSION[\t ]+([0-9\\.]+)$")
+  file(STRINGS "${PARMETIS_INCLUDE_DIR}/parmetis.h" parmetis_version REGEX ${version_pattern})
+
+  foreach(match ${parmetis_version})
+    if(PARMETIS_VERSION_STRING)
+      set(PARMETIS_VERSION_STRING "${PARMETIS_VERSION_STRING}.")
+    endif()
+    string(REGEX REPLACE ${version_pattern} "${PARMETIS_VERSION_STRING}\\2" PARMETIS_VERSION_STRING ${match})
+    set(PARMETIS_VERSION_${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
+  endforeach()
+  unset(parmetis_version)
+  unset(version_pattern)
+endif()
+
+# Standard package handling
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ParMETIS
+  REQUIRED_VARS ParMETIS_LIBRARY ParMETIS_INCLUDE_DIR
+  VERSION_VAR PARMETIS_VERSION_STRING
+)
+
+# Dependencies
+include(CMakeFindDependencyMacro)
+#find_dependency(MPI)
+find_dependency(METIS)
+
+if(ParMETIS_FOUND)
+  if(NOT TARGET ParMETIS::ParMETIS)
+    add_library(ParMETIS::ParMETIS UNKNOWN IMPORTED)
+  endif()
+  set_property(TARGET ParMETIS::ParMETIS PROPERTY IMPORTED_LOCATION "${ParMETIS_LIBRARY}")
+  set_property(TARGET ParMETIS::ParMETIS PROPERTY INTERFACE_LINK_LIBRARIES METIS::METIS)
+  set_property(TARGET ParMETIS::ParMETIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${ParMETIS_INCLUDE_DIRS}")
+endif()


### PR DESCRIPTION
This PR adds CMake scripts to find an external installation of ParMETIS.

I've added the `find_package(ParMETIS)` call at the location where it was commented out in the `CMakeLists.txt` so it will be called when when you pass "-Denable_parmetislib=OFF" to CMake. In this case `-- Will not link with ParMETIS` will be printed during the CMake configure step, which I find confusing. If you tell me how the desired output should look like I can change that.