### PR TITLE
Get superlu_dist to build without parmetis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 # Project version numbers
-project(SuperLU_DIST NONE)
+project(SuperLU_DIST LANGUAGES C)
 set(VERSION_MAJOR "5")
 set(VERSION_MINOR "2")
 set(VERSION_BugFix "2")
@@ -183,7 +183,7 @@ else()
   message("-- Will not link with ParMETIS.")
 endif()
 
-if(NOT enable_parmetislib)
+if(enable_parmetislib AND NOT PARMETIS_FOUND)
   find_package(ParMETIS)
   if(PARMETIS_FOUND)
     set(PARMETIS_LIB ParMETIS::ParMETIS)
@@ -198,8 +198,11 @@ endif()
 #
 ######################################################################
 
+include_directories(${CMAKE_BINARY_DIR}/SRC) # For superlu_dist_config.h
 include_directories(${CMAKE_SOURCE_DIR}/SRC)
-include_directories(${TPL_PARMETIS_INCLUDE_DIRS})  ## parmetis
+if (TPL_PARMETIS_INCLUDE_DIRS)
+  include_directories(${TPL_PARMETIS_INCLUDE_DIRS})  ## parmetis
+endif ()
 include_directories(${MPI_C_INCLUDE_PATH})
 
 ######################################################################
@@ -228,7 +231,7 @@ endif()
 # file(WRITE "make.defs" "# can be exposed to users" ${CMAKE_C_COMPILER})
 # configure_file(${CMAKE_SOURCE_DIR}/make.inc.in ${CMAKE_BINARY_DIR}/make.inc)
 configure_file(${SuperLU_DIST_SOURCE_DIR}/make.inc.in ${SuperLU_DIST_SOURCE_DIR}/make.inc)
-configure_file(${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h.in ${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h)
+configure_file(${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h.in ${SuperLU_DIST_BINARY_DIR}/SRC/superlu_dist_config.h)
 
 # Add pkg-config support
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu_dist.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu_dist.pc @ONLY)

--- a/EXAMPLE/pddrive.c
+++ b/EXAMPLE/pddrive.c
@@ -22,6 +22,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -151,6 +152,10 @@ int main(int argc, char *argv[])
         options.PrintStat         = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 #if 0
     options.RowPerm = NOROWPERM;
     options.IterRefine = NOREFINE;

--- a/EXAMPLE/pddrive1.c
+++ b/EXAMPLE/pddrive1.c
@@ -22,6 +22,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -151,6 +152,11 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
+    printf("options.ColPerm = %d\n", options.ColPerm);
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/EXAMPLE/pddrive2.c
+++ b/EXAMPLE/pddrive2.c
@@ -23,6 +23,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -156,6 +157,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/EXAMPLE/pddrive3.c
+++ b/EXAMPLE/pddrive3.c
@@ -22,6 +22,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -175,6 +176,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/EXAMPLE/pzdrive1.c
+++ b/EXAMPLE/pzdrive1.c
@@ -21,6 +21,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_zdefs.h"
 
 /*! \brief
@@ -150,6 +151,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/EXAMPLE/pzdrive2.c
+++ b/EXAMPLE/pzdrive2.c
@@ -22,6 +22,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_zdefs.h"
 
 /*! \brief
@@ -155,6 +156,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/EXAMPLE/pzdrive3.c
+++ b/EXAMPLE/pzdrive3.c
@@ -21,6 +21,7 @@ at the top-level directory.
  */
 
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_zdefs.h"
 
 /*! \brief
@@ -174,6 +175,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
 
     if (!iam) {
 	print_sp_ienv_dist(&options);

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -9,7 +9,7 @@ set(headers
     supermatrix.h
     util_dist.h
     colamd.h
-    superlu_dist_config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/superlu_dist_config.h
 )
 
 # first: precision-independent files

--- a/SRC/get_perm_c.c
+++ b/SRC/get_perm_c.c
@@ -22,6 +22,7 @@ at the top-level directory.
  *
  */
 
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 #include "colamd.h"
 
@@ -515,6 +516,7 @@ get_perm_c_dist(int_t pnum, int_t ispec, SuperMatrix *A, int_t *perm_c)
 	      printf(".. Use approximate minimum degree column ordering.\n");
 #endif
 	      return;
+#ifdef HAVE_PARMETIS
         case METIS_AT_PLUS_A: /* METIS ordering on A'+A */
 	      if ( m != n ) ABORT("Matrix is not square");
 	      at_plus_a_dist(n, Astore->nnz, Astore->colptr, Astore->rowind,
@@ -532,6 +534,7 @@ get_perm_c_dist(int_t pnum, int_t ispec, SuperMatrix *A, int_t *perm_c)
 	      if ( !pnum ) printf(".. Use METIS ordering on A'+A\n");
 #endif
 	      return;
+#endif
 
         default:
 	      ABORT("Invalid ISPEC");

--- a/SRC/get_perm_c.c
+++ b/SRC/get_perm_c.c
@@ -35,6 +35,7 @@ get_metis(
 	  int_t *perm_c    /* out - the column permutation vector. */
 	  )
 {
+#ifdef HAVE_PARMETIS
     /*#define METISOPTIONS 8*/
 #define METISOPTIONS 40
     int_t metis_options[METISOPTIONS];
@@ -101,6 +102,7 @@ get_metis(
     SUPERLU_FREE(b_rowind);
 #endif
     SUPERLU_FREE(perm);
+#endif /* HAVE_PARMETIS */
 }
 
 void

--- a/SRC/get_perm_c_parmetis.c
+++ b/SRC/get_perm_c_parmetis.c
@@ -24,7 +24,10 @@ at the top-level directory.
 /* limits.h:  the largest positive integer (INT_MAX) */
 #include <limits.h>
 #include <math.h>
+#include <superlu_dist_config.h>
+#ifdef HAVE_PARMETIS
 #include "parmetis.h"
+#endif
 #include "superlu_ddefs.h"
 
 /*
@@ -104,6 +107,9 @@ get_perm_c_parmetis (SuperMatrix *A, int_t *perm_r, int_t *perm_c,
 		     gridinfo_t *grid, MPI_Comm *metis_comm)
 
 {
+  float mem;  /* Memory used during this routine */
+  mem = 0.;
+#ifdef HAVE_PARMETIS
   NRformat_loc *Astore;
   int   iam, p;
 #if 0
@@ -123,7 +129,6 @@ get_perm_c_parmetis (SuperMatrix *A, int_t *perm_r, int_t *perm_c,
   int_t  *vtxdist_i, *vtxdist_o; 
   int_t szSep, k, noNodes;
   float apat_mem_l; /* memory used during the computation of the graph of A+A' */
-  float mem;  /* Memory used during this routine */
   MPI_Status status;
 
   /* Initialization. */
@@ -131,7 +136,6 @@ get_perm_c_parmetis (SuperMatrix *A, int_t *perm_r, int_t *perm_c,
   n = A->ncol;
   m = A->nrow;
   if ( m != n ) ABORT("Matrix is not square");
-  mem = 0.;
 
 #if ( DEBUGlevel>=1 )
   CHECK_MALLOC(iam, "Enter get_perm_c_parmetis()");
@@ -355,8 +359,8 @@ get_perm_c_parmetis (SuperMatrix *A, int_t *perm_r, int_t *perm_c,
   CHECK_MALLOC(iam, "Exit get_perm_c_parmetis()");
 #endif
   
+#endif /* HAVE_PARMETIS */
   return (-mem);
-
 } /* get_perm_c_parmetis */
 
 /*! \brief

--- a/SRC/superlu_dist_config.h.in
+++ b/SRC/superlu_dist_config.h.in
@@ -1,5 +1,8 @@
 /* superlu_dist_config.h.in */
 
+/* Enable parmetis */
+#cmakedefine HAVE_PARMETIS @HAVE_PARMETIS@
+
 /* enable 64bit index mode */
 #cmakedefine XSDK_INDEX_SIZE @XSDK_INDEX_SIZE@
 

--- a/TEST/pdtest.c
+++ b/TEST/pdtest.c
@@ -28,6 +28,7 @@ at the top-level directory.
 #include <unistd.h>
 #include <getopt.h>
 #include <math.h>
+#include <superlu_dist_config.h>
 #include "superlu_ddefs.h"
 
 #define NTESTS 1 /*5*/      /* Number of test types */
@@ -170,6 +171,10 @@ int main(int argc, char *argv[])
 
     /* Set the default input options. */
     set_default_options_dist(&options);
+#ifndef HAVE_PARMETIS
+    printf("No parmetis.\n");
+    options.ColPerm = MMD_AT_PLUS_A;
+#endif
     options.PrintStat = NO;
 	
     if (!iam) {


### PR DESCRIPTION
This will allow superlu_dist to build without parmetis.  It fixes the exclusion of parmetis with enable_parmetislib is set to false.  It removes the ispec = parmetis ordering choice, and it modifies all tests to use options.ColPerm = MMD_AT_PLUS_A;

It also generates superlu_dist_config.h in the build tree, so that the source tree remains clean, and adds the appropriate include directives