### PR TITLE
FIxes for windows: remove setenv, unistd, and libm

### DIFF
--- a/EXAMPLE/CMakeLists.txt
+++ b/EXAMPLE/CMakeLists.txt
@@ -1,7 +1,10 @@
 include_directories(${SuperLU_DIST_SOURCE_DIR}/SRC)
 
 # Libs linked to all of the examples
-set(all_link_libs superlu_dist ${BLAS_LIB} m)
+set(all_link_libs superlu_dist ${BLAS_LIB})
+if (NOT MSVC)
+  list(APPEND all_link_libs m)
+endif ()
 
 function(add_superlu_dist_example target input nprow npcol)
     set(EXAMPLE_INPUT "${SuperLU_DIST_SOURCE_DIR}/EXAMPLE/${input}")

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -121,8 +121,11 @@ if(enable_complex16)
 endif()
 
 add_library(superlu_dist ${sources} ${HEADERS})
-target_link_libraries(superlu_dist
-                      ${MPI_C_LIBRARIES} ${BLAS_LIB} ${PARMETIS_LIB} m)
+set(superlu_dist_libs ${MPI_C_LIBRARIES} ${BLAS_LIB} ${PARMETIS_LIB})
+if (NOT MSVC)
+  list(APPEND superlu_dist_libs m)
+endif ()
+target_link_libraries(superlu_dist ${superlu_dist_libs})
 set_target_properties(superlu_dist PROPERTIES
                       VERSION ${PROJECT_VERSION} SOVERSION ${VERSION_MAJOR}
 )

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -1,7 +1,10 @@
 include_directories(${SuperLU_DIST_SOURCE_DIR}/SRC)
 
 # Libs linked to all of the tests
-set(all_link_libs superlu_dist ${BLAS_LIB} m)
+set(all_link_libs superlu_dist ${BLAS_LIB})
+if (NOT MSVC)
+  list(APPEND all_link_libs m)
+endif ()
 
 set(MATRICES ../EXAMPLE/g20.rua)  # sample sparse matrix from a file
 set(NPROWS 1 2)		  # process rows

--- a/TEST/pdtest.c
+++ b/TEST/pdtest.c
@@ -446,6 +446,8 @@ parse_command_line(int argc, char *argv[], int *nprow, int *npcol,
     int c;
     extern char *optarg;
     char  str[20];
+    char *xenvstr, *menvstr, *benvstr, *genvstr;
+    xenvstr = menvstr = benvstr = genvstr = 0;
 
     while ( (c = getopt(argc, argv, "hr:c:t:n:x:m:b:g:s:f:")) != EOF ) {
 	switch (c) {
@@ -468,24 +470,44 @@ parse_command_line(int argc, char *argv[], int *nprow, int *npcol,
 	            break;
 	  case 'n': *n = atoi(optarg);
 	            break;
-	  case 'x': c = atoi(optarg); 
-	            sprintf(str, "%d", c);
-	            setenv("NREL", str, 1);
+// Use putenv as exists on Windows
+#ifdef _MSC_VER
+#define putenv _putenv
+#endif
+	  case 'x': // c = atoi(optarg); 
+	            // sprintf(str, "%d", c);
+	            // setenv("NREL", str, 1);
+		    xenvstr = (char*) malloc((6+strlen(optarg))*sizeof(char));
+		    strcpy(xenvstr, "NREL=");
+		    strcat(xenvstr, optarg);
+		    putenv(xenvstr);
 	            //printf("Reset relax env. variable to %d\n", c);
 	            break;
-	  case 'm': c = atoi(optarg); 
-	            sprintf(str, "%d", c);
-		    setenv("NSUP", str, 1);
+	  case 'm': // c = atoi(optarg); 
+	            // sprintf(str, "%d", c);
+		    // setenv("NSUP", str, 1);
+		    menvstr = (char*) malloc((6+strlen(optarg))*sizeof(char));
+		    strcpy(menvstr, "NSUP=");
+		    strcat(menvstr, optarg);
+		    putenv(menvstr);
 		    //printf("Reset maxsuper env. variable to %d\n", c);
 	            break;
-	  case 'b': c = atoi(optarg); 
-	            sprintf(str, "%d", c);
-		    setenv("FILL", str, 1);
+	  case 'b': // c = atoi(optarg); 
+	            // sprintf(str, "%d", c);
+		    // setenv("FILL", str, 1);
+		    benvstr = (char*) malloc((6+strlen(optarg))*sizeof(char));
+		    strcpy(benvstr, "FILL=");
+		    strcat(benvstr, optarg);
+		    putenv(benvstr);
 		    //printf("Reset fill_ratio env. variable to %d\n", c);
 	            break;
-	  case 'g': c = atoi(optarg); 
-	            sprintf(str, "%d", c);
-		    setenv("N_GEMM", str, 1);
+	  case 'g': // c = atoi(optarg); 
+	            // sprintf(str, "%d", c);
+		    // setenv("N_GEMM", str, 1);
+		    genvstr = (char*) malloc((8+strlen(optarg))*sizeof(char));
+		    strcpy(genvstr, "N_GEMM=");
+		    strcat(genvstr, optarg);
+		    putenv(genvstr);
 		    //printf("Reset min_gemm_gpu_offload env. variable to %d\n", c);
 	            break;
 	  case 's': *nrhs = atoi(optarg); 

--- a/TEST/pdtest.c
+++ b/TEST/pdtest.c
@@ -25,7 +25,7 @@ at the top-level directory.
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+// #include <unistd.h>
 #include <getopt.h>
 #include <math.h>
 #include <superlu_dist_config.h>


### PR DESCRIPTION
Windows has putenv (_putenv) but not setenv, so recoded to putenv.

The include of unistd.h is not needed anywhere and does not exist on Windows, so removed.

libm is not needed on Windows, so removed in cmake code if MSVC is defined.

Built and tested on MacOS.  Still need getopt replacement to get this to build on Windows.