### PR TITLE
Replace deprecated MPI_Attr_get.

### DIFF
--- a/SRC/pdgstrf.c
+++ b/SRC/pdgstrf.c
@@ -426,7 +426,7 @@ pdgstrf(superlu_dist_options_t * options, int m, int n, double anorm,
     s_eps = smach_dist("Epsilon");
     thresh = s_eps * anorm;
 
-    MPI_Attr_get (MPI_COMM_WORLD, MPI_TAG_UB, &attr_val, &flag);
+    MPI_Comm_get_attr (MPI_COMM_WORLD, MPI_TAG_UB, &attr_val, &flag);
     if (!flag) {
         fprintf (stderr, "Could not get TAG_UB\n");
         return (-1);

--- a/SRC/pzgstrf.c
+++ b/SRC/pzgstrf.c
@@ -426,7 +426,7 @@ pzgstrf(superlu_dist_options_t * options, int m, int n, double anorm,
     s_eps = smach_dist("Epsilon");
     thresh = s_eps * anorm;
 
-    MPI_Attr_get (MPI_COMM_WORLD, MPI_TAG_UB, &attr_val, &flag);
+    MPI_Comm_get_attr (MPI_COMM_WORLD, MPI_TAG_UB, &attr_val, &flag);
     if (!flag) {
         fprintf (stderr, "Could not get TAG_UB\n");
         return (-1);

--- a/SRC/superlu_grid.c
+++ b/SRC/superlu_grid.c
@@ -150,7 +150,7 @@ void superlu_gridmap(
     {
 	int tag_ub;
 	if ( !grid->iam ) {
-	    MPI_Attr_get(Bcomm, MPI_TAG_UB, &tag_ub, &info);
+	    MPI_Comm_get_attr(Bcomm, MPI_TAG_UB, &tag_ub, &info);
 	    printf("MPI_TAG_UB %d\n", tag_ub);
 	    /* returns 4295677672
 	       In reality it is restricted to no greater than 16384. */


### PR DESCRIPTION
Fixes build with OpenMPI version 4.0.

See https://github.com/xiaoyeli/superlu_dist/issues/35