### PR TITLE
Fix openmp build failures with Cray compiler.

### DIFF
--- a/SRC/pdgstrs_lsum.c
+++ b/SRC/pdgstrs_lsum.c
@@ -1139,7 +1139,7 @@ void dlsum_fmod_inv_master
 
 						RHS_ITERATE(j)
 							#ifdef _OPENMP
-								#pragma omp simd lastprivate(irow)
+								#pragma omp simd
 							#endif
 							for (i = 0; i < nbrow1; ++i) {
 								irow = lsub[lptr+i] - rel; /* Relative row. */

--- a/SRC/pzgstrs_lsum.c
+++ b/SRC/pzgstrs_lsum.c
@@ -1168,7 +1168,7 @@ void zlsum_fmod_inv_master
 
 						RHS_ITERATE(j)
 							#ifdef _OPENMP
-								#pragma omp simd lastprivate(irow)
+								#pragma omp simd
 							#endif
 							for (i = 0; i < nbrow1; ++i) {
 								irow = lsub[lptr+i] - rel; /* Relative row. */


### PR DESCRIPTION
The 'lastprivate' clause here causes a build failure with the Cray compiler:
CC-1653 craycc: ERROR File = ./SRC/pzgstrs_lsum.c,
Line = 1171
  The variable "irow" cannot be used in this lastprivate clause
  because the variable appears in a conflicting clause in an enclosing
  region.
                                      #pragma omp simd lastprivate(irow)
                                                                   ^

Since the `irow` variable is not used later in the enclosing taskloop, its
value is irrelevant, so just leave out the 'lastprivate' clause.

* SRC/pdgstrs_lsum.c (dlsum_fmod_inv_master): Remove lastprivate clause.
* SRC/pzgstrs_lsum.c (zlsum_fmod_inv_master): Ditto.