### PR TITLE
config: Let CMake handle C++11 flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ set(INSTALL_BIN_DIR "${default_install_bin_dir}" CACHE STRING "The folder where 
 # Set up required compiler defines and options.
 ## get_directory_property( DirDefs COMPILE_DEFINITIONS )
 # set(CMAKE_C_FLAGS "-DDEBUGlevel=0 -DPRNTlevel=0 ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 if(XSDK_INDEX_SIZE EQUAL 64)
     message("-- Using 64 bit integer for index size.")
 endif()	


### PR DESCRIPTION
Cmake already detects flags needed for C++ standard handling.  This allows SuperLU_DIST to configure cleanly with compilers that do not recognize the `-std=c++11` flag.

* CMakeLists.txt (CMAKE_CXX_FLAGS): Do not clobber with '-std=c++11'.