### PR TITLE
Add path to test executables

### DIFF
--- a/EXAMPLE/CMakeLists.txt
+++ b/EXAMPLE/CMakeLists.txt
@@ -18,7 +18,7 @@ function(add_superlu_dist_example target input nprow npcol)
 
 # corresponding to mpiexec -n 4 pddrive -r <nprow> -c <npcol> g20.rua
     add_test(${target} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${procs}
-             ${MPIEXEC_PREFLAGS} ${target} ${MPIEXEC_POSTFLAGS} -r "${nprow}" -c "${npcol}" "${EXAMPLE_INPUT}")
+             ${MPIEXEC_PREFLAGS} ${EXAMPLE_LOC}/${target} ${MPIEXEC_POSTFLAGS} -r "${nprow}" -c "${npcol}" "${EXAMPLE_INPUT}")
 
 #     add_test(NAME ${target} COMMAND "${CMAKE_COMMAND}"
 #              -DTEST=${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${procs}
@@ -76,12 +76,12 @@ if(enable_double)
   set(DEXMG4 pddrive4_ABglobal.c)
   add_executable(pddrive4_ABglobal ${DEXMG4})
   target_link_libraries(pddrive4_ABglobal ${all_link_libs})
-  
+
   set(DEXMS pddrive_spawn.c dcreate_matrix.c)
   add_executable(pddrive_spawn ${DEXMS})
-  target_link_libraries(pddrive_spawn ${all_link_libs})  
-  
-  
+  target_link_libraries(pddrive_spawn ${all_link_libs})
+
+
 endif()
 
 

--- a/TEST/CMakeLists.txt
+++ b/TEST/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 set(MATRICES ../EXAMPLE/g20.rua)  # sample sparse matrix from a file
 set(NPROWS 1 2 5)	  # process rows
-set(NPCOLS 1 2 3) 	  # process columns 
+set(NPCOLS 1 2 3) 	  # process columns
 set(NVAL 9 19)	  	  # generated matrix dimensions
 set(NRHS 1 3)		  # number of RHS
 # set(FILLRATIO 2 10)	  # estimated fill ratio
@@ -44,11 +44,11 @@ function(add_superlu_dist_tests target input)
 	      foreach (m ${SUPERSIZE})
                 set(testName "${target}_${r}x${c}_${s}_${b}_${x}_${m}")
 	  	set(SINGLE_OUTPUT ${SuperLU_DIST_BINARY_DIR}/TEST/${testName}.out)
-          add_test( ${testName}_SP 
+          add_test( ${testName}_SP
 	    	    ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${np}
-            	    ${MPIEXEC_PREFLAGS} ${target} ${MPIEXEC_POSTFLAGS} 
+            	    ${MPIEXEC_PREFLAGS} ${TEST_LOC}/${target} ${MPIEXEC_POSTFLAGS}
 		    -r ${r} -c ${c} -s ${s} -b ${b} -x ${x} -m ${m} -f ${TEST_INPUT}
-		  ) 
+		  )
 #          add_test( ${testName}_SP "${CMAKE_COMMAND}"
 #	    -DTEST=${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${np}
 #            ${MPIEXEC_PREFLAGS} ${target} ${MPIEXEC_POSTFLAGS} -r ${r} -c ${c} -s ${s} -b ${b} -x ${x} -m ${m} -f ${TEST_INPUT}


### PR DESCRIPTION
I installed SuperLU_DIST with CMake, but running ctest doesn't seem to work. I got the following error message:

```$ ctest -R pdtest_1x1_1_2_8_20_SP -V
UpdateCTestConfiguration  from :/home/vyu/opt/superlu_dist/build/DartConfiguration.tcl
Parse Config file:/home/vyu/opt/superlu_dist/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/vyu/opt/superlu_dist/build/DartConfiguration.tcl
Parse Config file:/home/vyu/opt/superlu_dist/build/DartConfiguration.tcl
Test project /home/vyu/opt/superlu_dist/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: pdtest_1x1_1_2_8_20_SP

1: Test command: /opt/intel/impi/2018.2.199/bin64/mpiexec "-n" "1" "pdtest" "-r" "1" "-c" "1" "-s" "1" "-b" "2" "-x" "8" "-m" "20" "-f" "/home/vyu/opt/superlu_dist/EXAMPLE/g20.rua"
1: Test timeout computed to be: 1500
1: [proxy:0:0@node16.timewarp] HYDU_create_process (../../utils/launch/launch.c:825): execvp error on file pdtest (No such file or directory)
1/1 Test #1: pdtest_1x1_1_2_8_20_SP ...........***Failed    0.06 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.08 sec

The following tests FAILED:
          1 - pdtest_1x1_1_2_8_20_SP (Failed)
Errors while running CTest
```

I think the problem is that ctest doesn't know where to locate the executables. This PR intends to fix this by adding the full path to executables in the TEST and EXAMPLE directories.