### PR TITLE
Install fortran bridge routines

### DIFF
--- a/FORTRAN/CMakeLists.txt
+++ b/FORTRAN/CMakeLists.txt
@@ -2,7 +2,11 @@
 include_directories(${SuperLU_DIST_SOURCE_DIR}/SRC)
 include_directories(${SuperLU_DIST_BINARY_DIR}/FORTRAN)
 
-set(sources "superlu_c2f_wrap.c")  # initialize precision-independent file
+set(sources
+    superlu_c2f_wrap.c  # initialize precision-independent file
+    superlupara.f90
+    superlu_mod.f90
+    )
 
 if(enable_double)
   list(APPEND sources c2f_dcreate_matrix_x_b.c superlu_c2f_dwrap.c)
@@ -53,25 +57,22 @@ if (NOT MSVC)
   list(APPEND all_link_libs m)
 endif ()
 
-
-add_library(ftestmod STATIC superlupara.f90 superlu_mod.f90)
-
 #if(enable_double)
 if(FALSE)
   set(F_DEXM ${F_MOD} f_pddrive.F90)
   add_executable(f_pddrive ${F_DEXM})
-  target_link_libraries(f_pddrive ftestmod ${all_link_libs})
+  target_link_libraries(f_pddrive ${all_link_libs})
   # set_target_properties(f_pddrive PROPERTIES LINKER_LANGUAGE Fortran CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   set_target_properties(f_pddrive PROPERTIES LINKER_LANGUAGE CXX LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")
   
   set(F_DEXM3D f_pddrive3d.F90)
   add_executable(f_pddrive3d ${F_DEXM3D})
-  target_link_libraries(f_pddrive3d ftestmod ${all_link_libs})
+  target_link_libraries(f_pddrive3d ${all_link_libs})
   set_target_properties(f_pddrive3d PROPERTIES LINKER_LANGUAGE CXX LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")
   
   set(F_5x5 f_5x5.F90 sp_ienv.c)
   add_executable(f_5x5 ${F_5x5})
-  target_link_libraries(f_5x5 ftestmod ${all_link_libs})
+  target_link_libraries(f_5x5 ${all_link_libs})
   set_target_properties(f_5x5 PROPERTIES LINKER_LANGUAGE CXX LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")
   
 endif()
@@ -80,13 +81,13 @@ endif()
 if(FALSE)
   set(F_ZEXM f_pzdrive.F90)
   add_executable(f_pzdrive ${F_ZEXM})
-  target_link_libraries(f_pzdrive ftestmod ${all_link_libs})
+  target_link_libraries(f_pzdrive ${all_link_libs})
 #  set_target_properties(f_pzdrive PROPERTIES LINKER_LANGUAGE Fortran)
   set_target_properties(f_pzdrive PROPERTIES LINKER_LANGUAGE CXX LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")
 
   set(F_ZEXM3D f_pzdrive3d.F90)
   add_executable(f_pzdrive3d ${F_ZEXM3D})
-  target_link_libraries(f_pzdrive3d ftestmod ${all_link_libs})
+  target_link_libraries(f_pzdrive3d ${all_link_libs})
   set_target_properties(f_pzdrive3d PROPERTIES LINKER_LANGUAGE CXX LINK_FLAGS "${MPI_Fortran_LINK_FLAGS}")
   
 endif()


### PR DESCRIPTION
Install fortran bridge routines so that they can be used in external packages beyond just the tests.