### PR TITLE
Skip cublas initialisation when GPU offloading is disabled at runtime (i.e., SUPERLU_ACC_OFFLOAD=0)

### DIFF
--- a/EXAMPLE/pddrive.c
+++ b/EXAMPLE/pddrive.c
@@ -155,26 +155,29 @@ int main(int argc, char *argv[])
         SUPERLU_FREE(usermap);
 
 #ifdef GPU_ACC
-        /* Binding each MPI to a GPU device */
-        char *ttemp;
-        ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+            /* Binding each MPI to a GPU device */
+            char *ttemp;
+            ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
 
-        if (ttemp) {
-	    int devs, rank;
-	    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
-	    gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
-	    gpuSetDevice(rank % devs); // Set device to be used for GPU executions
-        }
+            if (ttemp) {
+	        int devs, rank;
+	        MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
+	        gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
+	        gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+            }
 
-        // This is to initialize GPU, which can be costly. 
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+            // This is to initialize GPU, which can be costly.
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
+	}
 #endif
         // printf("grid.iam %5d, myrank %5d\n",grid.iam,myrank);
         // fflush(stdout);
@@ -186,15 +189,18 @@ int main(int argc, char *argv[])
         superlu_gridinit(MPI_COMM_WORLD, nprow, npcol, &grid);
 	
 #ifdef GPU_ACC
-        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+            MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
+	}
 #endif
     }
     

--- a/EXAMPLE/pddrive3d.c
+++ b/EXAMPLE/pddrive3d.c
@@ -222,26 +222,28 @@ main (int argc, char *argv[])
 	SUPERLU_FREE(usermap);
 
 #ifdef GPU_ACC
-	/* Binding each MPI to a GPU device */
-	char *ttemp;
-	ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+	    /* Binding each MPI to a GPU device */
+	    char *ttemp;
+	    ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
 
-	if (ttemp) {
-	    int devs, rank;
-	    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
-	    gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
-	    gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    if (ttemp) {
+	        int devs, rank;
+	        MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
+	        gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
+	        gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    }
+            // This is to initialize GPU, which can be costly.
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
 	}
-        // This is to initialize GPU, which can be costly. 
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
-
 #endif
 
 	// printf("grid.iam %5d, myrank %5d\n",grid.iam,myrank);
@@ -253,15 +255,18 @@ main (int argc, char *argv[])
            ------------------------------------------------------------ */
         superlu_gridinit3d (MPI_COMM_WORLD, nprow, npcol, npdep, &grid);
 #ifdef GPU_ACC
-        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+            MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
+	}
 #endif
     }
 

--- a/EXAMPLE/psdrive.c
+++ b/EXAMPLE/psdrive.c
@@ -155,26 +155,29 @@ int main(int argc, char *argv[])
         SUPERLU_FREE(usermap);
 
 #ifdef GPU_ACC
-        /* Binding each MPI to a GPU device */
-        char *ttemp;
-        ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+            /* Binding each MPI to a GPU device */
+            char *ttemp;
+            ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
 
-        if (ttemp) {
-	    int devs, rank;
-	    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
-	    gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
-	    gpuSetDevice(rank % devs); // Set device to be used for GPU executions
-        }
+            if (ttemp) {
+	        int devs, rank;
+	        MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
+	        gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
+	        gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+            }
 
-        // This is to initialize GPU, which can be costly. 
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+            // This is to initialize GPU, which can be costly.
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
+	}
 #endif
         // printf("grid.iam %5d, myrank %5d\n",grid.iam,myrank);
         // fflush(stdout);
@@ -186,15 +189,18 @@ int main(int argc, char *argv[])
         superlu_gridinit(MPI_COMM_WORLD, nprow, npcol, &grid);
 	
 #ifdef GPU_ACC
-        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+            MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+            double t1 = SuperLU_timer_();
+            gpuFree(0);
+            double t2 = SuperLU_timer_();
+            if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+            gpublasHandle_t hb;
+            gpublasCreate(&hb);
+            if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+            gpublasDestroy(hb);
+	}
 #endif
     }
     

--- a/EXAMPLE/psdrive3d.c
+++ b/EXAMPLE/psdrive3d.c
@@ -222,26 +222,28 @@ main (int argc, char *argv[])
 	SUPERLU_FREE(usermap);
 
 #ifdef GPU_ACC
-	/* Binding each MPI to a GPU device */
-	char *ttemp;
-	ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+	    /* Binding each MPI to a GPU device */
+	    char *ttemp;
+	    ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
 
-	if (ttemp) {
-	    int devs, rank;
-	    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
-	    gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
-	    gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    if (ttemp) {
+		int devs, rank;
+		MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
+		gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
+		gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    }
+	    // This is to initialize GPU, which can be costly.
+	    double t1 = SuperLU_timer_();
+	    gpuFree(0);
+	    double t2 = SuperLU_timer_();
+	    if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+	    gpublasHandle_t hb;
+	    gpublasCreate(&hb);
+	    if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+	    gpublasDestroy(hb);
 	}
-        // This is to initialize GPU, which can be costly. 
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
-
 #endif
 
 	// printf("grid.iam %5d, myrank %5d\n",grid.iam,myrank);
@@ -253,15 +255,18 @@ main (int argc, char *argv[])
            ------------------------------------------------------------ */
         superlu_gridinit3d (MPI_COMM_WORLD, nprow, npcol, npdep, &grid);
 #ifdef GPU_ACC
-        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+	    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+	    double t1 = SuperLU_timer_();
+	    gpuFree(0);
+	    double t2 = SuperLU_timer_();
+	    if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+	    gpublasHandle_t hb;
+	    gpublasCreate(&hb);
+	    if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+	    gpublasDestroy(hb);
+	}
 #endif
     }
 

--- a/EXAMPLE/pzdrive3d.c
+++ b/EXAMPLE/pzdrive3d.c
@@ -222,26 +222,28 @@ main (int argc, char *argv[])
 	SUPERLU_FREE(usermap);
 
 #ifdef GPU_ACC
-	/* Binding each MPI to a GPU device */
-	char *ttemp;
-	ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+	    /* Binding each MPI to a GPU device */
+	    char *ttemp;
+	    ttemp = getenv ("SUPERLU_BIND_MPI_GPU");
 
-	if (ttemp) {
-	    int devs, rank;
-	    MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
-	    gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
-	    gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    if (ttemp) {
+		int devs, rank;
+		MPI_Comm_rank(MPI_COMM_WORLD, &rank); // MPI_COMM_WORLD needs to be used here instead of SubComm
+		gpuGetDeviceCount(&devs);  // Returns the number of compute-capable devices
+		gpuSetDevice(rank % devs); // Set device to be used for GPU executions
+	    }
+	    // This is to initialize GPU, which can be costly.
+	    double t1 = SuperLU_timer_();
+	    gpuFree(0);
+	    double t2 = SuperLU_timer_();
+	    if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+	    gpublasHandle_t hb;
+	    gpublasCreate(&hb);
+	    if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+	    gpublasDestroy(hb);
 	}
-        // This is to initialize GPU, which can be costly. 
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
-
 #endif
 
 	// printf("grid.iam %5d, myrank %5d\n",grid.iam,myrank);
@@ -253,15 +255,18 @@ main (int argc, char *argv[])
            ------------------------------------------------------------ */
         superlu_gridinit3d (MPI_COMM_WORLD, nprow, npcol, npdep, &grid);
 #ifdef GPU_ACC
-        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
-        double t1 = SuperLU_timer_();                       
-        gpuFree(0);
-        double t2 = SuperLU_timer_();    
-        if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
-        gpublasHandle_t hb;           
-        gpublasCreate(&hb);
-        if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
-        gpublasDestroy(hb);
+        int superlu_acc_offload = get_acc_offload();
+        if (superlu_acc_offload) {
+	    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+	    double t1 = SuperLU_timer_();
+	    gpuFree(0);
+	    double t2 = SuperLU_timer_();
+	    if(!myrank)printf("first gpufree time: %7.4f\n",t2-t1);
+	    gpublasHandle_t hb;
+	    gpublasCreate(&hb);
+	    if(!myrank)printf("first blas create time: %7.4f\n",SuperLU_timer_()-t2);
+	    gpublasDestroy(hb);
+	}
 #endif
     }
 


### PR DESCRIPTION
This commit fixes a minor issue with pddrive when GPU offloading is disabled at runtime (i.e., SUPERLU_ACC_OFFLOAD=0) by skipping the initialisation of cublas. Otherwise, this could lead to an error or hang in cublasDestroy. (I observed this issue when running on CPU-only nodes of NERSC's Perlmutter with a version of SuperLU_dist that is built with GPU support enabled.)

The fix is simply to check the environment variable SUPERLU_ACC_OFFLOAD before initialising cublas.