### PR TITLE
Bcast xtrue to non-root ranks

### DIFF
--- a/EXAMPLE/pddrive_ABglobal.c
+++ b/EXAMPLE/pddrive_ABglobal.c
@@ -162,7 +162,11 @@ int main(int argc, char *argv[])
     *trans = 'N';
     ldx = n;
     ldb = m;
-    dGenXtrue_dist(n, nrhs, xtrue, ldx);
+    if ( !iam ){
+        dGenXtrue_dist(n, nrhs, xtrue, ldx);
+    } else {
+        MPI_Bcast(xtrue, m*nrhs, MPI_DOUBLE, 0, grid.comm);
+    }
     dFillRHS_dist(trans, nrhs, xtrue, ldx, &A, b, ldb);
 
     if ( !(berr = doubleMalloc_dist(nrhs)) )


### PR DESCRIPTION
I believe this is correct, I haven't run it though. This should fix the issue we faced with `xtrue` being different when the number of ranks are > 1.