### PR TITLE
Remove unused ptr and associated free

### DIFF
--- a/SRC/dlustruct_gpu.h
+++ b/SRC/dlustruct_gpu.h
@@ -96,8 +96,6 @@ typedef struct //LUstruct_gpu_
     local_u_blk_info_t *local_u_blk_infoVec;
 
     int_t *local_u_blk_infoPtr;
-    int_t *ijb_lookupVec;
-    int_t *ijb_lookupPtr;
 
     // GPU buffers for performing Schur Complement Update on GPU
     dSCUbuf_gpu_t scubufs[MAX_NGPU_STREAMS];

--- a/SRC/dsuperlu_gpu.cu
+++ b/SRC/dsuperlu_gpu.cu
@@ -795,12 +795,8 @@ int dfree_LUstruct_gpu (
 
 	checkGPU(gpuFree(A_gpu->local_l_blk_infoVec));
 	checkGPU(gpuFree(A_gpu->local_l_blk_infoPtr));
-	checkGPU(gpuFree(A_gpu->jib_lookupVec));
-	checkGPU(gpuFree(A_gpu->jib_lookupPtr));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoVec));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoPtr));
-	checkGPU(gpuFree(A_gpu->ijb_lookupVec));
-	checkGPU(gpuFree(A_gpu->ijb_lookupPtr));
 
 	/* Destroy all the meta-structures associated with the streams. */
     	gpuStreamDestroy(sluGPU->CopyStream);

--- a/SRC/slustruct_gpu.h
+++ b/SRC/slustruct_gpu.h
@@ -96,8 +96,6 @@ typedef struct //LUstruct_gpu_
     local_u_blk_info_t *local_u_blk_infoVec;
 
     int_t *local_u_blk_infoPtr;
-    int_t *ijb_lookupVec;
-    int_t *ijb_lookupPtr;
 
     // GPU buffers for performing Schur Complement Update on GPU
     sSCUbuf_gpu_t scubufs[MAX_NGPU_STREAMS];

--- a/SRC/ssuperlu_gpu.cu
+++ b/SRC/ssuperlu_gpu.cu
@@ -799,8 +799,6 @@ int sfree_LUstruct_gpu (
 	checkGPU(gpuFree(A_gpu->jib_lookupPtr));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoVec));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoPtr));
-	checkGPU(gpuFree(A_gpu->ijb_lookupVec));
-	checkGPU(gpuFree(A_gpu->ijb_lookupPtr));
 
 	/* Destroy all the meta-structures associated with the streams. */
     	gpuStreamDestroy(sluGPU->CopyStream);

--- a/SRC/zlustruct_gpu.h
+++ b/SRC/zlustruct_gpu.h
@@ -95,8 +95,6 @@ typedef struct //LUstruct_gpu_
     local_u_blk_info_t *local_u_blk_infoVec;
 
     int_t *local_u_blk_infoPtr;
-    int_t *ijb_lookupVec;
-    int_t *ijb_lookupPtr;
 
     // GPU buffers for performing Schur Complement Update on GPU
     zSCUbuf_gpu_t scubufs[MAX_NGPU_STREAMS];

--- a/SRC/zsuperlu_gpu.cu
+++ b/SRC/zsuperlu_gpu.cu
@@ -807,8 +807,6 @@ int zfree_LUstruct_gpu (
 	checkGPU(gpuFree(A_gpu->jib_lookupPtr));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoVec));
 	checkGPU(gpuFree(A_gpu->local_u_blk_infoPtr));
-	checkGPU(gpuFree(A_gpu->ijb_lookupVec));
-	checkGPU(gpuFree(A_gpu->ijb_lookupPtr));
 
 	/* Destroy all the meta-structures associated with the streams. */
     	gpuStreamDestroy(sluGPU->CopyStream);


### PR DESCRIPTION
I found a few pointers that were never used, expect in calls to free them. Not sure if it leads to memory errors, but triggers some warnings from valgrind