### PR TITLE
Fix incorrect call to dist_psymbtonum when fact is SamePattern_SameRowPerm

### DIFF
--- a/EXAMPLE/pddrive2.c
+++ b/EXAMPLE/pddrive2.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     double   *b, *b1, *xtrue, *xtrue1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -78,6 +78,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -99,6 +102,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -173,6 +182,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/EXAMPLE/pddrive3.c
+++ b/EXAMPLE/pddrive3.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     double   *b, *b1, *xtrue, *nzval, *nzval1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc, fst_row;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -75,6 +75,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -96,6 +99,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -188,6 +197,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/EXAMPLE/psdrive2.c
+++ b/EXAMPLE/psdrive2.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     float   *b, *b1, *xtrue, *xtrue1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -78,6 +78,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -99,6 +102,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -174,6 +183,10 @@ int main(int argc, char *argv[])
      */
     set_default_options_dist(&options);
     options.IterRefine = SLU_SINGLE;
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/EXAMPLE/psdrive3.c
+++ b/EXAMPLE/psdrive3.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     float   *b, *b1, *xtrue, *nzval, *nzval1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc, fst_row;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -75,6 +75,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -96,6 +99,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -189,6 +198,10 @@ int main(int argc, char *argv[])
      */
     set_default_options_dist(&options);
     options.IterRefine = SLU_SINGLE;
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/EXAMPLE/pzdrive2.c
+++ b/EXAMPLE/pzdrive2.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     doublecomplex   *b, *b1, *xtrue, *xtrue1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -77,6 +77,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -98,6 +101,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -172,6 +181,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/EXAMPLE/pzdrive3.c
+++ b/EXAMPLE/pzdrive3.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     doublecomplex   *b, *b1, *xtrue, *nzval, *nzval1;
     int_t    *colind, *colind1, *rowptr, *rowptr1;
     int_t    i, j, m, n, nnz_loc, m_loc, fst_row;
-    int      nprow, npcol;
+    int      nprow, npcol, colperm, rowperm, symbfact;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
@@ -74,6 +74,9 @@ int main(int argc, char *argv[])
     nprow = 1;  /* Default process rows.      */
     npcol = 1;  /* Default process columns.   */
     nrhs = 1;   /* Number of right-hand side. */
+    colperm = -1;
+    rowperm = -1;
+    symbfact = -1;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 
@@ -95,6 +98,12 @@ int main(int argc, char *argv[])
 	      case 'r': nprow = atoi(*cpp);
 		        break;
 	      case 'c': npcol = atoi(*cpp);
+		        break;
+	      case 'p': rowperm = atoi(*cpp);
+		        break;
+	      case 'q': colperm = atoi(*cpp);
+		        break;
+	      case 's': symbfact = atoi(*cpp);
 		        break;
 	    }
 	} else { /* Last arg is considered a filename */
@@ -187,6 +196,10 @@ int main(int argc, char *argv[])
         options.PrintStat = YES;
      */
     set_default_options_dist(&options);
+
+    if (rowperm != -1) options.RowPerm = rowperm;
+    if (colperm != -1) options.ColPerm = colperm;
+    if (symbfact != -1) options.ParSymbFact = symbfact;
 
     if (!iam) {
 	print_options_dist(&options);

--- a/SRC/pdgssvx.c
+++ b/SRC/pdgssvx.c
@@ -1132,8 +1132,7 @@ pdgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 	if (symb_comm != MPI_COMM_NULL) MPI_Comm_free (&symb_comm);
 
 	/* Distribute entries of A into L & U data structures. */
-	//if (parSymbFact == NO || ???? Fact == SamePattern_SameRowPerm) {
-	if ( parSymbFact == NO ) {
+	if ( parSymbFact == NO || Fact == SamePattern_SameRowPerm ) {
 	    /* CASE OF SERIAL SYMBOLIC */
   	    /* Apply column permutation to the original distributed A */
 	    for (j = 0; j < nnz_loc; ++j) colind[j] = perm_c[colind[j]];

--- a/SRC/psgssvx.c
+++ b/SRC/psgssvx.c
@@ -1133,8 +1133,7 @@ psgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 	if (symb_comm != MPI_COMM_NULL) MPI_Comm_free (&symb_comm);
 
 	/* Distribute entries of A into L & U data structures. */
-	//if (parSymbFact == NO || ???? Fact == SamePattern_SameRowPerm) {
-	if ( parSymbFact == NO ) {
+	if ( parSymbFact == NO || Fact == SamePattern_SameRowPerm ) {
 	    /* CASE OF SERIAL SYMBOLIC */
   	    /* Apply column permutation to the original distributed A */
 	    for (j = 0; j < nnz_loc; ++j) colind[j] = perm_c[colind[j]];

--- a/SRC/pzgssvx.c
+++ b/SRC/pzgssvx.c
@@ -1134,8 +1134,7 @@ pzgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 	if (symb_comm != MPI_COMM_NULL) MPI_Comm_free (&symb_comm);
 
 	/* Distribute entries of A into L & U data structures. */
-	//if (parSymbFact == NO || ???? Fact == SamePattern_SameRowPerm) {
-	if ( parSymbFact == NO ) {
+	if ( parSymbFact == NO || Fact == SamePattern_SameRowPerm ) {
 	    /* CASE OF SERIAL SYMBOLIC */
   	    /* Apply column permutation to the original distributed A */
 	    for (j = 0; j < nnz_loc; ++j) colind[j] = perm_c[colind[j]];


### PR DESCRIPTION
Hi Sherry,

I found this issue while testing a combination of reusing the row and column permutations (SamePattern_SameRowPerm) and using parallel symbolic factorisation. This would fail with the assertion:

  `ERROR: call of dist_psymbtonum with fact equals SamePattern_SameRowPerm.`

I also found the following lines in `pdgssvx()` near the call to `ddist_psymbtonum()`:

```
	//if (parSymbFact == NO || ???? Fact == SamePattern_SameRowPerm) {
	if ( parSymbFact == NO ) {
```

Everything seems to work fine after I uncommented the top line and removed the bottom one.

It would be great if you could confirm if you think this is indeed a correct fix.

Thanks!