### PR TITLE
Fix issue when sequential column permutations vary between processes

### DIFF
--- a/SRC/pdgssvx.c
+++ b/SRC/pdgssvx.c
@@ -1021,7 +1021,7 @@ pdgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 		  return;
      	      }
 	  } else {
-	      get_perm_c_dist(iam, permc_spec, &GA, perm_c);
+	      get_perm_c_dist(iam, permc_spec, &GA, perm_c, grid->comm);
           }
         }
 

--- a/SRC/pdgssvx3d.c
+++ b/SRC/pdgssvx3d.c
@@ -1073,7 +1073,7 @@ pdgssvx3d (superlu_dist_options_t * options, SuperMatrix * A,
 		    if (flinfo > 0)
 			ABORT ("ERROR in get perm_c parmetis.");
 		} else {
-		    get_perm_c_dist (iam, permc_spec, &GA, perm_c);
+		    get_perm_c_dist (iam, permc_spec, &GA, perm_c, grid->comm);
 		}
 	    }
 

--- a/SRC/pdgssvx_ABglobal.c
+++ b/SRC/pdgssvx_ABglobal.c
@@ -855,7 +855,7 @@ pdgssvx_ABglobal(superlu_dist_options_t *options, SuperMatrix *A,
 	permc_spec = options->ColPerm;
 	if ( permc_spec != MY_PERMC && Fact == DOFACT )
 	    /* Use an ordering provided by SuperLU */
-	    get_perm_c_dist(iam, permc_spec, A, perm_c);
+	    get_perm_c_dist(iam, permc_spec, A, perm_c, grid->comm);
 
 	/* Compute the elimination tree of Pc*(A'+A)*Pc' or Pc*A'*A*Pc'
 	   (a.k.a. column etree), depending on the choice of ColPerm.

--- a/SRC/psgssvx.c
+++ b/SRC/psgssvx.c
@@ -1021,7 +1021,7 @@ psgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 		  return;
      	      }
 	  } else {
-	      get_perm_c_dist(iam, permc_spec, &GA, perm_c);
+	      get_perm_c_dist(iam, permc_spec, &GA, perm_c, grid->comm);
           }
         }
 

--- a/SRC/psgssvx3d.c
+++ b/SRC/psgssvx3d.c
@@ -1068,7 +1068,7 @@ psgssvx3d (superlu_dist_options_t * options, SuperMatrix * A,
 		    if (flinfo > 0)
 			ABORT ("ERROR in get perm_c parmetis.");
 		} else {
-		    get_perm_c_dist (iam, permc_spec, &GA, perm_c);
+		    get_perm_c_dist (iam, permc_spec, &GA, perm_c, grid->comm);
 		}
 	    }
 

--- a/SRC/psgssvx_ABglobal.c
+++ b/SRC/psgssvx_ABglobal.c
@@ -855,7 +855,7 @@ psgssvx_ABglobal(superlu_dist_options_t *options, SuperMatrix *A,
 	permc_spec = options->ColPerm;
 	if ( permc_spec != MY_PERMC && Fact == DOFACT )
 	    /* Use an ordering provided by SuperLU */
-	    get_perm_c_dist(iam, permc_spec, A, perm_c);
+	    get_perm_c_dist(iam, permc_spec, A, perm_c, grid->comm);
 
 	/* Compute the elimination tree of Pc*(A'+A)*Pc' or Pc*A'*A*Pc'
 	   (a.k.a. column etree), depending on the choice of ColPerm.

--- a/SRC/psgssvx_d2.c
+++ b/SRC/psgssvx_d2.c
@@ -1075,7 +1075,7 @@ psgssvx_d2(superlu_dist_options_t *options, SuperMatrix *A,
 		  return;
      	      }
 	  } else {
-	      get_perm_c_dist(iam, permc_spec, &GA, perm_c);
+	      get_perm_c_dist(iam, permc_spec, &GA, perm_c, grid->comm);
           }
         }
 

--- a/SRC/pzgssvx.c
+++ b/SRC/pzgssvx.c
@@ -1022,7 +1022,7 @@ pzgssvx(superlu_dist_options_t *options, SuperMatrix *A,
 		  return;
      	      }
 	  } else {
-	      get_perm_c_dist(iam, permc_spec, &GA, perm_c);
+	      get_perm_c_dist(iam, permc_spec, &GA, perm_c, grid->comm);
           }
         }
 

--- a/SRC/pzgssvx3d.c
+++ b/SRC/pzgssvx3d.c
@@ -1069,7 +1069,7 @@ pzgssvx3d (superlu_dist_options_t * options, SuperMatrix * A,
 		    if (flinfo > 0)
 			ABORT ("ERROR in get perm_c parmetis.");
 		} else {
-		    get_perm_c_dist (iam, permc_spec, &GA, perm_c);
+		    get_perm_c_dist (iam, permc_spec, &GA, perm_c, grid->comm);
 		}
 	    }
 

--- a/SRC/pzgssvx_ABglobal.c
+++ b/SRC/pzgssvx_ABglobal.c
@@ -854,7 +854,7 @@ pzgssvx_ABglobal(superlu_dist_options_t *options, SuperMatrix *A,
 	permc_spec = options->ColPerm;
 	if ( permc_spec != MY_PERMC && Fact == DOFACT )
 	    /* Use an ordering provided by SuperLU */
-	    get_perm_c_dist(iam, permc_spec, A, perm_c);
+	    get_perm_c_dist(iam, permc_spec, A, perm_c, grid->comm);
 
 	/* Compute the elimination tree of Pc*(A'+A)*Pc' or Pc*A'*A*Pc'
 	   (a.k.a. column etree), depending on the choice of ColPerm.

--- a/SRC/superlu_defs.h
+++ b/SRC/superlu_defs.h
@@ -1064,10 +1064,9 @@ extern "C" {
 extern void   superlu_gridinit(MPI_Comm, int, int, gridinfo_t *);
 extern void   superlu_gridmap(MPI_Comm, int, int, int [], int, gridinfo_t *);
 extern void   superlu_gridexit(gridinfo_t *);
-extern void   superlu_gridinit3d(MPI_Comm Bcomm,  int nprow, int npcol, int npdep,
-				 gridinfo3d_t *grid) ;
+extern void   superlu_gridinit3d(MPI_Comm, int, int, int, gridinfo3d_t *) ;
 extern void   superlu_gridmap3d(MPI_Comm, int, int, int, int [], gridinfo3d_t *);
-extern void   superlu_gridexit3d(gridinfo3d_t *grid);
+extern void   superlu_gridexit3d(gridinfo3d_t *);
 
 extern void   set_default_options_dist(superlu_dist_options_t *);
 extern void   print_options_dist(superlu_dist_options_t *);
@@ -1082,17 +1081,17 @@ extern void   sp_colorder (superlu_dist_options_t*, SuperMatrix*, int_t*, int_t*
 			   SuperMatrix*);
 extern int    sp_symetree_dist(int_t *, int_t *, int_t *, int_t, int_t *);
 extern int    sp_coletree_dist (int_t *, int_t *, int_t *, int_t, int_t, int_t *);
-extern void   get_perm_c_dist(int_t, int_t, SuperMatrix *, int_t *);
+extern void   get_perm_c_dist(int_t, int_t, SuperMatrix *, int_t *, MPI_Comm);
 extern void   at_plus_a_dist(const int_t, const int_t, int_t *, int_t *,
 			     int_t *, int_t **, int_t **);
-extern int    genmmd_dist_(int_t *, int_t *, int_t *a, 
+extern int    genmmd_dist_(int_t *, int_t *, int_t *,
 			   int_t *, int_t *, int_t *, int_t *, 
 			   int_t *, int_t *, int_t *, int_t *, int_t *);
 extern void  bcast_tree(void *, int, MPI_Datatype, int, int,
 			gridinfo_t *, int, int *);
 extern int_t symbfact(superlu_dist_options_t *, int, SuperMatrix *, int_t *,
                       int_t *, Glu_persist_t *, Glu_freeable_t *);
-extern int_t symbfact_SubInit(superlu_dist_options_t *options,
+extern int_t symbfact_SubInit(superlu_dist_options_t *,
 			      fact_t, void *, int_t, int_t, int_t, int_t,
 			      Glu_persist_t *, Glu_freeable_t *);
 extern int_t symbfact_SubXpand(int_t, int_t, int_t, MemType, int_t *,
@@ -1190,10 +1189,10 @@ extern int_t get_num_gpu_streams (void);
 extern int getnGPUStreams(void);
 extern int get_mpi_process_per_gpu (void);
 /*to print out various statistics from GPU activities*/
-extern void printGPUStats(int nsupers, SuperLUStat_t *stat, gridinfo3d_t*);
+extern void printGPUStats(int, SuperLUStat_t *, gridinfo3d_t *);
 #endif
 
-extern double estimate_cpu_time(int m, int n , int k);
+extern double estimate_cpu_time(int, int, int k);
 
 extern int get_thread_per_process(void);
 extern int_t get_max_buffer_size (void);
@@ -1208,7 +1207,7 @@ extern int get_acc_offload(void);
 extern void  print_panel_seg_dist(int_t, int_t, int_t, int_t, int_t *, int_t *);
 extern void  check_repfnz_dist(int_t, int_t, int_t, int_t *);
 extern int_t CheckZeroDiagonal(int_t, int_t *, int_t *, int_t *);
-extern int   check_perm_dist(char *what, int_t n, int_t *perm);
+extern int   check_perm_dist(char *, int_t, int_t *);
 extern void  PrintDouble5(char *, int_t, double *);
 extern void  PrintInt10(char *, int_t, int_t *);
 extern void  PrintInt32(char *, int, int *);


### PR DESCRIPTION
I ran into an issue using the `METIS_AT_PLUS_A` reordering that the computed column permutation was different on different MPI processes, causing issues down the line in the symbolic factorization. This was using Scotch's METIS compatibility library, where it appears that recent versions of Scotch may produce slightly different results for calls to `METIS_NodeND` with the same inputs.

This PR resolves this issue by computing the column permutation on the root process and broadcasting to all other processes. This is the same approach taken by, for example, STRUMPACK when not using parallel reordering methods.