### PR TITLE
Fix memory error when using parallel symbolic factorization (ParMETIS)

### DIFF
--- a/SRC/prec-independent/psymbfact.c
+++ b/SRC/prec-independent/psymbfact.c
@@ -2156,17 +2156,16 @@ symbfact_vtx
 
 	/* TEST available memory */
 	if (next >= x_aind_end) {	
+	  int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
 	  if (domain_symb) {
-	      int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24 
 	      if ( (mem_error =
 		    psymbfact_LUXpandMem (iam, n, vtx, next, 0,
-					  //computeL, DOMAIN_SYMB, 1, 
-					  mem_type, DOMAIN_SYMB, 1, 
+					  mem_type, DOMAIN_SYMB, 1,
 					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
 		  return (mem_error);
 	  } else if ( (mem_error =
 		       psymbfact_LUXpand (iam, n, SLU_EMPTY, vtx, &next, 0, 
-					  computeL, LL_SYMB, 1, 
+					  mem_type, LL_SYMB, 1,
 					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
 	    return (mem_error);
 
@@ -3317,10 +3316,13 @@ expand_RL
   }
 
   nextl = xlsub[vtxXp_lid+1];  
-  if ( (mem_error = 
-	psymbfact_LUXpand_RL (iam, n, vtxXp, nextl, len_texp, 
-			      computeL, Pslu_freeable, Llu_symbfact, VInfo, PS)) )
-      return (mem_error);
+  {
+		int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
+		if ( (mem_error =
+		psymbfact_LUXpand_RL (iam, n, vtxXp, nextl, len_texp,
+				      mem_type, Pslu_freeable, Llu_symbfact, VInfo, PS)) )
+		    return (mem_error);
+  }
 
   return 0;
 }
@@ -4014,7 +4016,6 @@ dnsCurSep_symbfact
 	      int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24 
 	      if ( (mem_error =
 		    psymbfact_LUXpandMem (iam, n, vtx, next, next + j,
-					  //computeL, DNS_CURSEP, 1,
 					  mem_type, DNS_CURSEP, 1,
 					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
 	      return (mem_error);

--- a/SRC/prec-independent/psymbfact.c
+++ b/SRC/prec-independent/psymbfact.c
@@ -2154,20 +2154,20 @@ symbfact_vtx
       pr_elt = sub_src[k];
       if (pr_elt >= vtx && marker[pr_elt] != mark_vtx) {
 
-	/* TEST available memory */
-	if (next >= x_aind_end) {	
-	  int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
-	  if (domain_symb) {
-	      if ( (mem_error =
-		    psymbfact_LUXpandMem (iam, n, vtx, next, 0,
-					  mem_type, DOMAIN_SYMB, 1,
-					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
-		  return (mem_error);
-	  } else if ( (mem_error =
-		       psymbfact_LUXpand (iam, n, SLU_EMPTY, vtx, &next, 0, 
-					  mem_type, LL_SYMB, 1,
-					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
-	    return (mem_error);
+  /* TEST available memory */
+  if (next >= x_aind_end) {
+    int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
+    if (domain_symb) {
+      if ( (mem_error =
+            psymbfact_LUXpandMem (iam, n, vtx, next, 0,
+                                  mem_type, DOMAIN_SYMB, 1,
+                                  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
+        return (mem_error);
+    } else if ( (mem_error =
+                 psymbfact_LUXpand (iam, n, SLU_EMPTY, vtx, &next, 0,
+                                    mem_type, LL_SYMB, 1,
+                                    Pslu_freeable, Llu_symbfact, VInfo, PS)) )
+      return (mem_error);
 
 	  x_aind_end = xsub[vtx_lid + 1];
 	  if (computeL)   sub = Llu_symbfact->lsub; 
@@ -3317,11 +3317,11 @@ expand_RL
 
   nextl = xlsub[vtxXp_lid+1];  
   {
-		int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
-		if ( (mem_error =
-		psymbfact_LUXpand_RL (iam, n, vtxXp, nextl, len_texp,
-				      mem_type, Pslu_freeable, Llu_symbfact, VInfo, PS)) )
-		    return (mem_error);
+    int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
+    if ( (mem_error =
+          psymbfact_LUXpand_RL (iam, n, vtxXp, nextl, len_texp,
+                                mem_type, Pslu_freeable, Llu_symbfact, VInfo, PS)) )
+      return (mem_error);
   }
 
   return 0;
@@ -4009,19 +4009,19 @@ dnsCurSep_symbfact
 	  }
 	  xsub[vtx_lid] = next;
 
-	  /* TEST available memory */
-	  j = x_newelts[vtx_lid_x+1] + lstVtx - vtx;
-	  if ((computeL && next+j >= MEM_LSUB(Llu_symbfact, VInfo)) ||
-	      (computeU && next+j >= MEM_USUB(Llu_symbfact, VInfo))) {
-	      int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24 
-	      if ( (mem_error =
-		    psymbfact_LUXpandMem (iam, n, vtx, next, next + j,
-					  mem_type, DNS_CURSEP, 1,
-					  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
-	      return (mem_error);
-	    if (computeL) sub = Llu_symbfact->lsub;
-	    else sub = Llu_symbfact->usub; 
-	  }
+    /* TEST available memory */
+    j = x_newelts[vtx_lid_x+1] + lstVtx - vtx;
+    if ((computeL && next+j >= MEM_LSUB(Llu_symbfact, VInfo)) ||
+        (computeU && next+j >= MEM_USUB(Llu_symbfact, VInfo))) {
+      int mem_type = (computeL ? LSUB : USUB);  // Sherry fix 5/26/24
+      if ( (mem_error =
+            psymbfact_LUXpandMem (iam, n, vtx, next, next + j,
+                                  mem_type, DNS_CURSEP, 1,
+                                  Pslu_freeable, Llu_symbfact, VInfo, PS)) )
+        return (mem_error);
+      if (computeL) sub = Llu_symbfact->lsub;
+      else sub = Llu_symbfact->usub;
+    }
 	  
 	  if (computeL)  i = vtx;
 	  else           i = vtx+1;


### PR DESCRIPTION
Resolves #161. Results from changes made in [e207691](https://github.com/xiaoyeli/superlu_dist/commit/e2076918152efa9a6d44bf87e4c7fef9efd6d5d2#diff-4964d63c55baaf45c54e2d8b0485e230848b1a9da1d7c9fa40bdc3f77442c08d), which were partially fixed by [fe88f03](https://github.com/xiaoyeli/superlu_dist/commit/fe88f03d1f9d9ba67c9431c07b40b2b7c961961d#diff-6a9cc4f8cce1de786b86f0b60631990b57f0c49fd29bc2db87b894512073165b).