### PR TITLE
Try to recover 64-bit indices functionality

### DIFF
--- a/EXAMPLE/pddrive3d.c
+++ b/EXAMPLE/pddrive3d.c
@@ -351,8 +351,8 @@ int main (int argc, char *argv[])
 	double **ReqPtr;
 	double **CeqPtr;
 	DiagScale_t *DiagScale;
-	int **RpivPtr;
-	int **CpivPtr;
+	int_t **RpivPtr;
+	int_t **CpivPtr;
 	double **Xptr;
 	int *ldX;
 	double **xtrues;
@@ -376,15 +376,15 @@ int main (int argc, char *argv[])
 	
 	ReqPtr = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
 	CeqPtr = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
-	RpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
-	CpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
+	RpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
+	CpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
 	DiagScale = (DiagScale_t *) SUPERLU_MALLOC( batchCount * sizeof(DiagScale_t) );
 	Xptr = (double **) SUPERLU_MALLOC( batchCount * sizeof(double*) );
 	Berrs = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
 	for (int d = 0; d < batchCount; ++d) {
 	    DiagScale[d] = NOEQUIL;
-	    RpivPtr[d] = int32Malloc_dist(m);
-	    CpivPtr[d] = int32Malloc_dist(n);
+	    RpivPtr[d] = intMalloc_dist(m);
+	    CpivPtr[d] = intMalloc_dist(n);
 	    Xptr[d] = doubleMalloc_dist( n *  nrhs );
 	    Berrs[d] = doubleMalloc_dist( nrhs );
 	}

--- a/EXAMPLE/psdrive3d.c
+++ b/EXAMPLE/psdrive3d.c
@@ -351,8 +351,8 @@ int main (int argc, char *argv[])
 	float **ReqPtr;
 	float **CeqPtr;
 	DiagScale_t *DiagScale;
-	int **RpivPtr;
-	int **CpivPtr;
+	int_t **RpivPtr;
+	int_t **CpivPtr;
 	float **Xptr;
 	int *ldX;
 	float **xtrues;
@@ -376,15 +376,15 @@ int main (int argc, char *argv[])
 	
 	ReqPtr = (float **) SUPERLU_MALLOC( batchCount * sizeof(float *) );
 	CeqPtr = (float **) SUPERLU_MALLOC( batchCount * sizeof(float *) );
-	RpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
-	CpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
+	RpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
+	CpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
 	DiagScale = (DiagScale_t *) SUPERLU_MALLOC( batchCount * sizeof(DiagScale_t) );
 	Xptr = (float **) SUPERLU_MALLOC( batchCount * sizeof(float*) );
 	Berrs = (float **) SUPERLU_MALLOC( batchCount * sizeof(float *) );
 	for (int d = 0; d < batchCount; ++d) {
 	    DiagScale[d] = NOEQUIL;
-	    RpivPtr[d] = int32Malloc_dist(m);
-	    CpivPtr[d] = int32Malloc_dist(n);
+	    RpivPtr[d] = intMalloc_dist(m);
+	    CpivPtr[d] = intMalloc_dist(n);
 	    Xptr[d] = floatMalloc_dist( n *  nrhs );
 	    Berrs[d] = floatMalloc_dist( nrhs );
 	}

--- a/EXAMPLE/pzdrive3d.c
+++ b/EXAMPLE/pzdrive3d.c
@@ -351,8 +351,8 @@ int main (int argc, char *argv[])
 	double **ReqPtr;
 	double **CeqPtr;
 	DiagScale_t *DiagScale;
-	int **RpivPtr;
-	int **CpivPtr;
+	int_t **RpivPtr;
+	int_t **CpivPtr;
 	doublecomplex **Xptr;
 	int *ldX;
 	doublecomplex **xtrues;
@@ -376,15 +376,15 @@ int main (int argc, char *argv[])
 	
 	ReqPtr = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
 	CeqPtr = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
-	RpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
-	CpivPtr = (int **) SUPERLU_MALLOC( batchCount * sizeof(int *) );
+	RpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
+	CpivPtr = (int_t **) SUPERLU_MALLOC( batchCount * sizeof(int_t *) );
 	DiagScale = (DiagScale_t *) SUPERLU_MALLOC( batchCount * sizeof(DiagScale_t) );
 	Xptr = (doublecomplex **) SUPERLU_MALLOC( batchCount * sizeof(doublecomplex*) );
 	Berrs = (double **) SUPERLU_MALLOC( batchCount * sizeof(double *) );
 	for (int d = 0; d < batchCount; ++d) {
 	    DiagScale[d] = NOEQUIL;
-	    RpivPtr[d] = int32Malloc_dist(m);
-	    CpivPtr[d] = int32Malloc_dist(n);
+	    RpivPtr[d] = intMalloc_dist(m);
+	    CpivPtr[d] = intMalloc_dist(n);
 	    Xptr[d] = doublecomplexMalloc_dist( n *  nrhs );
 	    Berrs[d] = doubleMalloc_dist( nrhs );
 	}

--- a/SRC/complex16/pzgssvx3d_csc_batch.c
+++ b/SRC/complex16/pzgssvx3d_csc_batch.c
@@ -94,8 +94,8 @@ pzgssvx3d_csc_batch(
 				     each of size M   */
 		double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 				    each of size N    */
-		int **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
-		int **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
+		int_t **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
+		int_t **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
 		DiagScale_t *DiagScale, /* indicate how equilibration is done for each matrix */
 		handle_t *F, /* array of handles pointing to the factored matrices */
  		doublecomplex **Xptr, // array of pointers to dense solution storage
@@ -250,7 +250,7 @@ pzgssvx3d_csc_batch(
     int_t *colind_d;
     int_t *rowptr_d;
     int_t nnz_d, col, row;
-    int *perm_c, *perm_r;
+    int_t *perm_c, *perm_r;
 
     /* B_big */
     doublecomplex *b;
@@ -442,7 +442,7 @@ pzgssvx3d_csc_batch(
 
 	A = (SuperMatrix *) SparseMatrix_handles[d];
 	perm_c = CpivPtr[d];
-        perm_r = RpivPtr[d];
+	perm_r = RpivPtr[d];
 
 	/* Permute the solution matrix z <= Pc'*y */
 	//PrintInt32("prepare Pc'*y: perm_c", n, perm_c);

--- a/SRC/complex16/zpivot_batch.c
+++ b/SRC/complex16/zpivot_batch.c
@@ -54,7 +54,7 @@ zpivot_batch(
     double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 			each of size N    */
     DiagScale_t *DiagScale, /* How equilibration is done for each matrix. */
-    int **RpivPtr /* array of pointers to row permutation vectors , each of size M */
+    int_t **RpivPtr /* array of pointers to row permutation vectors , each of size M */
     //    DeviceContext context /* device context including queues, events, dependencies */
 		  )
 {
@@ -121,7 +121,7 @@ zpivot_batch(
 
 	if ( !factored ) { /* Skip this if already factored. */
 	    
-	    int *perm_r = RpivPtr[d];
+	    int_t *perm_r = RpivPtr[d];
 
 	    /* ------------------------------------------------------------
 	       Find the row permutation for A.

--- a/SRC/double/dpivot_batch.c
+++ b/SRC/double/dpivot_batch.c
@@ -55,7 +55,7 @@ dpivot_batch(
     double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 			each of size N    */
     DiagScale_t *DiagScale, /* How equilibration is done for each matrix. */
-    int **RpivPtr /* array of pointers to row permutation vectors , each of size M */
+    int_t **RpivPtr /* array of pointers to row permutation vectors , each of size M */
     //    DeviceContext context /* device context including queues, events, dependencies */
 		  )
 {
@@ -122,7 +122,7 @@ dpivot_batch(
 
 	if ( !factored ) { /* Skip this if already factored. */
 	    
-	    int *perm_r = RpivPtr[d];
+	    int_t *perm_r = RpivPtr[d];
 
 	    /* ------------------------------------------------------------
 	       Find the row permutation for A.

--- a/SRC/double/pdgssvx3d_csc_batch.c
+++ b/SRC/double/pdgssvx3d_csc_batch.c
@@ -95,8 +95,8 @@ pdgssvx3d_csc_batch(
 				     each of size M   */
 		double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 				    each of size N    */
-		int **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
-		int **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
+		int_t **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
+		int_t **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
 		DiagScale_t *DiagScale, /* indicate how equilibration is done for each matrix */
 		handle_t *F, /* array of handles pointing to the factored matrices */
  		double **Xptr, // array of pointers to dense solution storage
@@ -251,7 +251,7 @@ pdgssvx3d_csc_batch(
     int_t *colind_d;
     int_t *rowptr_d;
     int_t nnz_d, col, row;
-    int *perm_c, *perm_r;
+    int_t *perm_c, *perm_r;
 
     /* B_big */
     double *b;
@@ -443,7 +443,7 @@ pdgssvx3d_csc_batch(
 
 	A = (SuperMatrix *) SparseMatrix_handles[d];
 	perm_c = CpivPtr[d];
-        perm_r = RpivPtr[d];
+	perm_r = RpivPtr[d];
 
 	/* Permute the solution matrix z <= Pc'*y */
 	//PrintInt32("prepare Pc'*y: perm_c", n, perm_c);

--- a/SRC/include/superlu_ddefs.h
+++ b/SRC/include/superlu_ddefs.h
@@ -1594,7 +1594,7 @@ extern int pdgssvx3d_csc_batch(
 		superlu_dist_options_t *, int batchCount, int m, int n,	int nnz,
 		int nrhs, handle_t *, double **RHSptr, int *ldRHS,
 		double **ReqPtr, double **CeqPtr,
-		int **RpivPtr, int **CpivPtr, DiagScale_t *DiagScale,
+		int_t **RpivPtr, int_t **CpivPtr, DiagScale_t *DiagScale,
 		handle_t *F, double **Xptr, int *ldX, double **Berrs,
 		gridinfo3d_t *grid3d, SuperLUStat_t *stat, int *info
 		//DeviceContext context /* device context including queues, events, dependencies */
@@ -1606,7 +1606,7 @@ extern int dequil_batch(
     );
 extern int dpivot_batch(
     superlu_dist_options_t *, int batchCount, int m, int n, handle_t *,
-    double **ReqPtr, double **CeqPtr, DiagScale_t *, int **RpivPtr
+    double **ReqPtr, double **CeqPtr, DiagScale_t *, int_t **RpivPtr
     //    DeviceContext context /* device context including queues, events, dependencies */
     );
 

--- a/SRC/include/superlu_defs.h
+++ b/SRC/include/superlu_defs.h
@@ -1102,7 +1102,7 @@ extern int    sp_symetree_dist(int_t *, int_t *, int_t *, int_t, int_t *);
 extern int    sp_coletree_dist (int_t *, int_t *, int_t *, int_t, int_t, int_t *);
 extern void   get_perm_c_dist(int_t, int_t, SuperMatrix *, int_t *);
 extern void   get_perm_c_batch(superlu_dist_options_t *options,	int batchCount,
-			       handle_t  *SparseMatrix_handles, int **CpivPtr);
+			       handle_t  *SparseMatrix_handles, int_t **CpivPtr);
 extern void   at_plus_a_dist(const int_t, const int_t, int_t *, int_t *,
 			     int_t *, int_t **, int_t **);
 extern void   getata_dist(const int_t m, const int_t n, const int_t nz, int_t *colptr, int_t *rowind,

--- a/SRC/include/superlu_sdefs.h
+++ b/SRC/include/superlu_sdefs.h
@@ -1594,7 +1594,7 @@ extern int psgssvx3d_csc_batch(
 		superlu_dist_options_t *, int batchCount, int m, int n,	int nnz,
 		int nrhs, handle_t *, float **RHSptr, int *ldRHS,
 		float **ReqPtr, float **CeqPtr,
-		int **RpivPtr, int **CpivPtr, DiagScale_t *DiagScale,
+		int_t **RpivPtr, int_t **CpivPtr, DiagScale_t *DiagScale,
 		handle_t *F, float **Xptr, int *ldX, float **Berrs,
 		gridinfo3d_t *grid3d, SuperLUStat_t *stat, int *info
 		//DeviceContext context /* device context including queues, events, dependencies */
@@ -1606,7 +1606,7 @@ extern int sequil_batch(
     );
 extern int spivot_batch(
     superlu_dist_options_t *, int batchCount, int m, int n, handle_t *,
-    float **ReqPtr, float **CeqPtr, DiagScale_t *, int **RpivPtr
+    float **ReqPtr, float **CeqPtr, DiagScale_t *, int_t **RpivPtr
     //    DeviceContext context /* device context including queues, events, dependencies */
     );
 

--- a/SRC/include/superlu_zdefs.h
+++ b/SRC/include/superlu_zdefs.h
@@ -1596,7 +1596,7 @@ extern int pzgssvx3d_csc_batch(
 		superlu_dist_options_t *, int batchCount, int m, int n,	int nnz,
 		int nrhs, handle_t *, doublecomplex **RHSptr, int *ldRHS,
 		double **ReqPtr, double **CeqPtr,
-		int **RpivPtr, int **CpivPtr, DiagScale_t *DiagScale,
+		int_t **RpivPtr, int_t **CpivPtr, DiagScale_t *DiagScale,
 		handle_t *F, doublecomplex **Xptr, int *ldX, double **Berrs,
 		gridinfo3d_t *grid3d, SuperLUStat_t *stat, int *info
 		//DeviceContext context /* device context including queues, events, dependencies */
@@ -1608,7 +1608,7 @@ extern int zequil_batch(
     );
 extern int zpivot_batch(
     superlu_dist_options_t *, int batchCount, int m, int n, handle_t *,
-    double **ReqPtr, double **CeqPtr, DiagScale_t *, int **RpivPtr
+    double **ReqPtr, double **CeqPtr, DiagScale_t *, int_t **RpivPtr
     //    DeviceContext context /* device context including queues, events, dependencies */
     );
 

--- a/SRC/prec-independent/get_perm_c_batch.c
+++ b/SRC/prec-independent/get_perm_c_batch.c
@@ -42,7 +42,7 @@ get_perm_c_batch(
 					  * of size 'batchCount',
 					  * each pointing to the actual storage
 					  */
-	int **CpivPtr /* array of pointers to column permutation vectors , each of size N */
+	int_t **CpivPtr /* array of pointers to column permutation vectors , each of size N */
 		 )
 {
 #if ( DEBUGlevel>=1 )
@@ -90,7 +90,7 @@ get_perm_c_batch(
     for (int d = 0; d < batchCount; ++d) {
 	
 	NCformat *Astore = (NCformat *) A[d]->Store;
-	int *perm_c = CpivPtr[d];
+	int_t *perm_c = CpivPtr[d];
 
 	t = SuperLU_timer_();
 	bnz = 0;

--- a/SRC/single/psgssvx3d_csc_batch.c
+++ b/SRC/single/psgssvx3d_csc_batch.c
@@ -95,8 +95,8 @@ psgssvx3d_csc_batch(
 				     each of size M   */
 		float **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 				    each of size N    */
-		int **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
-		int **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
+		int_t **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
+		int_t **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
 		DiagScale_t *DiagScale, /* indicate how equilibration is done for each matrix */
 		handle_t *F, /* array of handles pointing to the factored matrices */
  		float **Xptr, // array of pointers to dense solution storage
@@ -251,7 +251,7 @@ psgssvx3d_csc_batch(
     int_t *colind_d;
     int_t *rowptr_d;
     int_t nnz_d, col, row;
-    int *perm_c, *perm_r;
+    int_t *perm_c, *perm_r;
 
     /* B_big */
     float *b;
@@ -443,7 +443,7 @@ psgssvx3d_csc_batch(
 
 	A = (SuperMatrix *) SparseMatrix_handles[d];
 	perm_c = CpivPtr[d];
-        perm_r = RpivPtr[d];
+	perm_r = RpivPtr[d];
 
 	/* Permute the solution matrix z <= Pc'*y */
 	//PrintInt32("prepare Pc'*y: perm_c", n, perm_c);

--- a/SRC/single/spivot_batch.c
+++ b/SRC/single/spivot_batch.c
@@ -55,7 +55,7 @@ spivot_batch(
     float **CeqPtr, /* array of pointers to diagonal column scaling vectors,
 			each of size N    */
     DiagScale_t *DiagScale, /* How equilibration is done for each matrix. */
-    int **RpivPtr /* array of pointers to row permutation vectors , each of size M */
+    int_t **RpivPtr /* array of pointers to row permutation vectors , each of size M */
     //    DeviceContext context /* device context including queues, events, dependencies */
 		  )
 {
@@ -122,7 +122,7 @@ spivot_batch(
 
 	if ( !factored ) { /* Skip this if already factored. */
 	    
-	    int *perm_r = RpivPtr[d];
+	    int_t *perm_r = RpivPtr[d];
 
 	    /* ------------------------------------------------------------
 	       Find the row permutation for A.


### PR DESCRIPTION
Hi,

I hope I didn't break the code too much. :)
At least on my machine, I can now compile with 64-bit indices through PETSc's `--with-64-bit-indices`.

Cheers,
-Nuno