### PR TITLE
Remove non-prototype declarations of fopen

### DIFF
--- a/EXAMPLE/dreadtriple.c
+++ b/EXAMPLE/dreadtriple.c
@@ -162,7 +162,7 @@ dreadtriple(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 void dreadrhs(int m, double *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i, j;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/EXAMPLE/pddrive.c
+++ b/EXAMPLE/pddrive.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
     int ldumap, myrank, p; /* The following variables are used for batch solves */

--- a/EXAMPLE/pddrive1.c
+++ b/EXAMPLE/pddrive1.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int    iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive1_ABglobal.c
+++ b/EXAMPLE/pddrive1_ABglobal.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive2.c
+++ b/EXAMPLE/pddrive2.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     /* prototypes */

--- a/EXAMPLE/pddrive2_ABglobal.c
+++ b/EXAMPLE/pddrive2_ABglobal.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive3.c
+++ b/EXAMPLE/pddrive3.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive3_ABglobal.c
+++ b/EXAMPLE/pddrive3_ABglobal.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive3d.c
+++ b/EXAMPLE/pddrive3d.c
@@ -114,7 +114,7 @@ int main (int argc, char *argv[])
     int equil, colperm, rowperm, ir, lookahead;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/pddrive3d1.c
+++ b/EXAMPLE/pddrive3d1.c
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/pddrive3d2.c
+++ b/EXAMPLE/pddrive3d2.c
@@ -117,7 +117,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/pddrive3d3.c
+++ b/EXAMPLE/pddrive3d3.c
@@ -123,7 +123,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs, ii, omp_mpi_level;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
 
     nprow = 1;            /* Default process rows.      */

--- a/EXAMPLE/pddrive3d_block_diag.c
+++ b/EXAMPLE/pddrive3d_block_diag.c
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/pddrive4.c
+++ b/EXAMPLE/pddrive4.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     int ii, omp_mpi_level;
     char     **cpp, c, *postfix;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
 

--- a/EXAMPLE/pddrive4_ABglobal.c
+++ b/EXAMPLE/pddrive4_ABglobal.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 

--- a/EXAMPLE/pddrive_ABglobal.c
+++ b/EXAMPLE/pddrive_ABglobal.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pddrive_spawn.c
+++ b/EXAMPLE/pddrive_spawn.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int      nprow, npcol,lookahead,colperm;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
 	MPI_Comm parent;

--- a/EXAMPLE/psdrive.c
+++ b/EXAMPLE/psdrive.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
     int ldumap, myrank, p; /* The following variables are used for batch solves */

--- a/EXAMPLE/psdrive1.c
+++ b/EXAMPLE/psdrive1.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int    iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/psdrive1_ABglobal.c
+++ b/EXAMPLE/psdrive1_ABglobal.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/psdrive2.c
+++ b/EXAMPLE/psdrive2.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     /* prototypes */

--- a/EXAMPLE/psdrive2_ABglobal.c
+++ b/EXAMPLE/psdrive2_ABglobal.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/psdrive3.c
+++ b/EXAMPLE/psdrive3.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/psdrive3_ABglobal.c
+++ b/EXAMPLE/psdrive3_ABglobal.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/psdrive3d.c
+++ b/EXAMPLE/psdrive3d.c
@@ -114,7 +114,7 @@ int main (int argc, char *argv[])
     int equil, colperm, rowperm, ir, lookahead;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/psdrive3d1.c
+++ b/EXAMPLE/psdrive3d1.c
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/psdrive3d2.c
+++ b/EXAMPLE/psdrive3d2.c
@@ -117,7 +117,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/psdrive3d3.c
+++ b/EXAMPLE/psdrive3d3.c
@@ -123,7 +123,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs, ii, omp_mpi_level;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
 
     nprow = 1;            /* Default process rows.      */

--- a/EXAMPLE/psdrive4.c
+++ b/EXAMPLE/psdrive4.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     int ii, omp_mpi_level;
     char     **cpp, c, *postfix;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
 

--- a/EXAMPLE/psdrive4_ABglobal.c
+++ b/EXAMPLE/psdrive4_ABglobal.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT.

--- a/EXAMPLE/psdrive_ABglobal.c
+++ b/EXAMPLE/psdrive_ABglobal.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive.c
+++ b/EXAMPLE/pzdrive.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
     int ldumap, myrank, p; /* The following variables are used for batch solves */

--- a/EXAMPLE/pzdrive1.c
+++ b/EXAMPLE/pzdrive1.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int    iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive1_ABglobal.c
+++ b/EXAMPLE/pzdrive1_ABglobal.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive2.c
+++ b/EXAMPLE/pzdrive2.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     /* prototypes */

--- a/EXAMPLE/pzdrive2_ABglobal.c
+++ b/EXAMPLE/pzdrive2_ABglobal.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive3.c
+++ b/EXAMPLE/pzdrive3.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;
     int ii, omp_mpi_level;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive3_ABglobal.c
+++ b/EXAMPLE/pzdrive3_ABglobal.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive3d.c
+++ b/EXAMPLE/pzdrive3d.c
@@ -114,7 +114,7 @@ int main (int argc, char *argv[])
     int equil, colperm, rowperm, ir, lookahead;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/pzdrive3d1.c
+++ b/EXAMPLE/pzdrive3d1.c
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/pzdrive3d2.c
+++ b/EXAMPLE/pzdrive3d2.c
@@ -117,7 +117,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level;
 

--- a/EXAMPLE/pzdrive3d3.c
+++ b/EXAMPLE/pzdrive3d3.c
@@ -123,7 +123,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs, ii, omp_mpi_level;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
 
     nprow = 1;            /* Default process rows.      */

--- a/EXAMPLE/pzdrive4.c
+++ b/EXAMPLE/pzdrive4.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     int ii, omp_mpi_level;
     char     **cpp, c, *postfix;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
 
 

--- a/EXAMPLE/pzdrive4_ABglobal.c
+++ b/EXAMPLE/pzdrive4_ABglobal.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     int      nrhs = 1;   /* Number of right-hand side. */
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
 
     /* ------------------------------------------------------------
        INITIALIZE MPI ENVIRONMENT. 

--- a/EXAMPLE/pzdrive_ABglobal.c
+++ b/EXAMPLE/pzdrive_ABglobal.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     int      iam, info, ldb, ldx, nrhs;
     char     trans[1];
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     extern int cpp_defs();
 
     nprow = 1;  /* Default process rows.      */

--- a/EXAMPLE/pzdrive_spawn.c
+++ b/EXAMPLE/pzdrive_spawn.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
     int      nprow, npcol,lookahead,colperm;
     int      iam, info, ldb, ldx, nrhs;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
 	MPI_Comm parent;

--- a/EXAMPLE/zreadtriple.c
+++ b/EXAMPLE/zreadtriple.c
@@ -161,7 +161,7 @@ zreadtriple(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 void zreadrhs(int m, doublecomplex *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i, j;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/FORTRAN/c2f_dcreate_matrix_x_b.c
+++ b/FORTRAN/c2f_dcreate_matrix_x_b.c
@@ -99,7 +99,7 @@ int c2f_dcreate_matrix_x_b(char *fname, int nrhs, int nprocs,
     char     trans[1];
 
     char     **cpp, c, *postfix;;
-    FILE     *fp, *fopen();
+    FILE     *fp;
     
     MPI_Comm_rank(slucomm, &iam);
 

--- a/FORTRAN/c2f_zcreate_matrix_x_b.c
+++ b/FORTRAN/c2f_zcreate_matrix_x_b.c
@@ -98,7 +98,7 @@ int c2f_zcreate_matrix_x_b(char *fname, int nrhs, int nprocs,
     char     trans[1];
 
     char     **cpp, c, *postfix;;
-    FILE     *fp, *fopen();
+    FILE     *fp;
     
     MPI_Comm_rank(slucomm, &iam);
 

--- a/PYTHON/pdbridge.c
+++ b/PYTHON/pdbridge.c
@@ -92,7 +92,7 @@ void pdbridge_init2d(int_t m, int_t n, int_t nnz, int_t *rowind, int_t *colptr ,
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch, sympattern;
     int      iam, info, ldb, ldx;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level;
     int ldumap, myrank, p; /* The following variables are used for batch solves */
@@ -332,7 +332,7 @@ void pdbridge_init3d (int_t m, int_t n, int_t nnz, int_t *rowind, int_t *colptr 
     int equil, colperm, rowperm, ir, lookahead, sympattern, symbfact;
     int iam, info, ldb, ldx;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */
@@ -608,7 +608,7 @@ void pdbridge_factor2d(void ** pyobj)
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch;
     int      iam, info, ldb, ldx;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level,m;
     int ldumap, myrank, p; /* The following variables are used for batch solves */
@@ -703,7 +703,7 @@ void pdbridge_factor3d (void ** pyobj)
     int equil, colperm, rowperm, ir, lookahead, sympattern;
     int iam, info, ldb, ldx;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0, m, i, j;
     int*    usermap;     /* The following variables are used for batch solves */
@@ -797,7 +797,7 @@ void pdbridge_solve2d(void ** pyobj, int nrhs, double   *b_global)
     int      nprow, npcol, lookahead, colperm, rowperm, ir, symbfact, batch;
     int      iam, info, ldb, ldx;
     char     **cpp, c, *postfix;;
-    FILE *fp, *fopen();
+    FILE *fp;
     int cpp_defs();
     int ii, omp_mpi_level,m;
     int ldumap, myrank, p; /* The following variables are used for batch solves */
@@ -904,7 +904,7 @@ void pdbridge_solve3d (void ** pyobj, int nrhs, double   *b_global)
     int equil, colperm, rowperm, ir, lookahead, sympattern;
     int iam, info, ldb, ldx;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0, m, i, j;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/SRC/complex16/pzgstrf.c
+++ b/SRC/complex16/pzgstrf.c
@@ -375,7 +375,7 @@ pzgstrf(superlu_dist_options_t * options, int m, int n, double anorm,
     float msg_vol = 0, msg_cnt = 0;
     double comm_wait_time = 0.0;
     /* Record GEMM dimensions and times */
-    FILE *fopen(), *fgemm;
+    FILE *fgemm;
     int gemm_count = 0;
     typedef struct {
 	int m, n, k;

--- a/SRC/complex16/zreadMM.c
+++ b/SRC/complex16/zreadMM.c
@@ -228,7 +228,7 @@ zreadMM_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 static void zreadrhs(int m, doublecomplex *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/complex16/zreadtriple.c
+++ b/SRC/complex16/zreadtriple.c
@@ -164,7 +164,7 @@ zreadtriple_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 void zreadrhs(int m, doublecomplex *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/complex16/zreadtriple_noheader.c
+++ b/SRC/complex16/zreadtriple_noheader.c
@@ -182,7 +182,7 @@ zreadtriple_noheader(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 #if 0
 void zreadrhs(int m, doublecomplex *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i, j;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/complex16/zutil_dist.c
+++ b/SRC/complex16/zutil_dist.c
@@ -843,7 +843,7 @@ void zDumpLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *index;
     doublecomplex *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 
 	// assert(grid->npcol*grid->nprow==1);
 
@@ -1162,7 +1162,7 @@ void zDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     doublecomplex *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/SRC/double/dreadMM.c
+++ b/SRC/double/dreadMM.c
@@ -229,7 +229,7 @@ dreadMM_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 static void dreadrhs(int m, double *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/double/dreadtriple.c
+++ b/SRC/double/dreadtriple.c
@@ -165,7 +165,7 @@ dreadtriple_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 void dreadrhs(int m, double *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/double/dreadtriple_noheader.c
+++ b/SRC/double/dreadtriple_noheader.c
@@ -183,7 +183,7 @@ dreadtriple_noheader(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 #if 0
 void dreadrhs(int m, double *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i, j;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/double/dutil_dist.c
+++ b/SRC/double/dutil_dist.c
@@ -845,7 +845,7 @@ void dDumpLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *index;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 
 	// assert(grid->npcol*grid->nprow==1);
 
@@ -944,7 +944,7 @@ void dComputeLevelsets(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *index,*lloc;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 
 	// assert(grid->npcol*grid->nprow==1);
 
@@ -985,7 +985,7 @@ void dGenCOOLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *xsup = Glu_persist->xsup;
     int_t *index;
     double *nzval;
-	FILE *fp, *fopen();
+	FILE *fp;
 
 	assert(grid->npcol*grid->nprow==1);
 
@@ -1092,7 +1092,7 @@ void dGenCSCLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *xsup = Glu_persist->xsup;
     int_t *index;
     double *nzval0;
-	FILE *fp, *fopen();
+	FILE *fp;
 
     double *val;
     int_t  *row, *col;
@@ -1245,7 +1245,7 @@ void dGenCSRLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *xsup = Glu_persist->xsup;
     int_t *index;
     double *nzval0;
-	FILE *fp, *fopen();
+	FILE *fp;
 
     double *val;
     int_t  *row, *col;
@@ -1730,7 +1730,7 @@ void dDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/SRC/double/pdgstrf.c
+++ b/SRC/double/pdgstrf.c
@@ -375,7 +375,7 @@ pdgstrf(superlu_dist_options_t * options, int m, int n, double anorm,
     float msg_vol = 0, msg_cnt = 0;
     double comm_wait_time = 0.0;
     /* Record GEMM dimensions and times */
-    FILE *fopen(), *fgemm;
+    FILE *fgemm;
     int gemm_count = 0;
     typedef struct {
 	int m, n, k;

--- a/SRC/double/pdgstrs.c
+++ b/SRC/double/pdgstrs.c
@@ -1581,7 +1581,7 @@ t1 = SuperLU_timer_();
 
 #if 0  // this will readin a matrix with only lower triangular part, note that this code block is only for benchmarking cusparse performance
 
-	FILE *fp, *fopen();
+	FILE *fp;
 	if ( !(fp = fopen("/gpfs/alpine/scratch/liuyangz/csc289/matrix/HTS/copter2.mtx", "r")) ) {
 	// if ( !(fp = fopen("/gpfs/alpine/scratch/liuyangz/csc289/matrix/HTS/epb3.mtx", "r")) ) {
 	// if ( !(fp = fopen("/gpfs/alpine/scratch/liuyangz/csc289/matrix/HTS/gridgena.mtx", "r")) ) {

--- a/SRC/single/psgstrf.c
+++ b/SRC/single/psgstrf.c
@@ -375,7 +375,7 @@ psgstrf(superlu_dist_options_t * options, int m, int n, float anorm,
     float msg_vol = 0, msg_cnt = 0;
     double comm_wait_time = 0.0;
     /* Record GEMM dimensions and times */
-    FILE *fopen(), *fgemm;
+    FILE *fgemm;
     int gemm_count = 0;
     typedef struct {
 	int m, n, k;

--- a/SRC/single/sreadMM.c
+++ b/SRC/single/sreadMM.c
@@ -229,7 +229,7 @@ sreadMM_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 static void sreadrhs(int m, float *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/single/sreadtriple.c
+++ b/SRC/single/sreadtriple.c
@@ -165,7 +165,7 @@ sreadtriple_dist(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 
 void sreadrhs(int m, float *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/single/sreadtriple_noheader.c
+++ b/SRC/single/sreadtriple_noheader.c
@@ -183,7 +183,7 @@ sreadtriple_noheader(FILE *fp, int_t *m, int_t *n, int_t *nonz,
 #if 0
 void sreadrhs(int m, float *b)
 {
-    FILE *fp, *fopen();
+    FILE *fp;
     int i, j;
 
     if ( !(fp = fopen("b.dat", "r")) ) {

--- a/SRC/single/sutil_dist.c
+++ b/SRC/single/sutil_dist.c
@@ -845,7 +845,7 @@ void sDumpLblocks(int iam, int_t nsupers, gridinfo_t *grid,
     int_t *index;
     float *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 
 	// assert(grid->npcol*grid->nprow==1);
 
@@ -1275,7 +1275,7 @@ void sDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     float *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/SRC_OLD/pdgssvx3d_1pass_Yang.c
+++ b/SRC_OLD/pdgssvx3d_1pass_Yang.c
@@ -613,7 +613,7 @@ void dDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/SRC_OLD/pdgssvx3d_2pass_Yang.c
+++ b/SRC_OLD/pdgssvx3d_2pass_Yang.c
@@ -615,7 +615,7 @@ void dDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/SRC_OLD/pdgssvx3d_piyush.c
+++ b/SRC_OLD/pdgssvx3d_piyush.c
@@ -613,7 +613,7 @@ void dDumpLblocks3D(int_t nsupers, gridinfo3d_t *grid3d,
     int_t *index;
     double *nzval;
 	char filename[256];
-	FILE *fp, *fopen();
+	FILE *fp;
 	gridinfo_t *grid = &(grid3d->grid2d);
 	int iam = grid->iam;
 	int iam3d = grid3d->iam;

--- a/TEST/pdtest.c
+++ b/TEST/pdtest.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     int    nprow, npcol;
     int    iam, info, ldb, ldx, nrhs, iinfo;
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     char matrix_type[8], equed[1];
     int  relax, maxsuper, fill_ratio, min_gemm_gpu_offload=0;
     int    equil, ifact, nfact, iequil, iequed, prefact, notfactored, diaginv;

--- a/TEST/pstest.c
+++ b/TEST/pstest.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     int    nprow, npcol;
     int    iam, info, ldb, ldx, nrhs, iinfo;
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     char matrix_type[8], equed[1];
     int  relax, maxsuper, fill_ratio, min_gemm_gpu_offload=0;
     int    equil, ifact, nfact, iequil, iequed, prefact, notfactored, diaginv;

--- a/TEST/pztest.c
+++ b/TEST/pztest.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     int    nprow, npcol;
     int    iam, info, ldb, ldx, nrhs, iinfo;
     char     **cpp, c;
-    FILE *fp, *fopen();
+    FILE *fp;
     char matrix_type[8], equed[1];
     int  relax, maxsuper, fill_ratio, min_gemm_gpu_offload=0;
     int    equil, ifact, nfact, iequil, iequed, prefact, notfactored, diaginv;


### PR DESCRIPTION
Hi Sherry (@xiaoyeli),

With C23, which is the new default with gcc 15, function declarations without parameters mean literally a function taking no arguments. Fortunately, the declaration of `fopen` is available from standard headers so all I had to do was remove our declaration. This worked for me when building PETSc, let's see if it doesn't break the CI tests (which are passing without this PR, even with gcc 15, because we're passing `-std=c11`).

Cheers,
Nuno