### PR TITLE
fix get_acc_offload and get_acc_solve

### DIFF
--- a/SRC/prec-independent/sec_structs.c
+++ b/SRC/prec-independent/sec_structs.c
@@ -583,7 +583,7 @@ int
 get_acc_offload (superlu_dist_options_t *options)
 {
 #ifdef GPU_ACC
-    sp_ienv_dist(10, options);
+    return sp_ienv_dist(10, options);
 #else
     return 0;  
 #endif        
@@ -594,7 +594,7 @@ get_acc_solve ()
 {
     superlu_dist_options_t *options = NULL; // not accessed 
 #ifdef GPU_ACC
-    sp_ienv_dist(11, options);
+    return sp_ienv_dist(11, options);
 #else
     return 0;  
 #endif        


### PR DESCRIPTION
Both functions didn't actually return their values before. So the GPU solve was not correctly activated by setting the environment variable `SUPERLU_ACC_SOLVE`.