### PR TITLE
Fix FORTRAN/sp_ienv.c case 2 returning hardcoded 1 instead of computed relax

### DIFF
--- a/FORTRAN/sp_ienv.c
+++ b/FORTRAN/sp_ienv.c
@@ -99,8 +99,7 @@ sp_ienv_dist(int ispec, superlu_dist_options_t *options)
 		k = options->superlu_relax;
 	    }
 	    k = SUPERLU_MIN( k, sp_ienv_dist(3,options) ); // not to exceed MAXSUP
-	    //return (k);
-	    return (1);
+	    return (k);
 	    
 	case 3: 
 	    ttemp = getenv("SUPERLU_MAXSUP"); // take min of MAX_SUPER_SIZE in superlu_defs.h


### PR DESCRIPTION
## Summary
- Restores `return (k);` in `FORTRAN/sp_ienv.c` case 2, which commit f972dd1f inadvertently changed to `return (1);` (leaving the prior `return (k);` as a commented-out line directly above).
- Effect today: `sp_ienv_dist(2, options)` always returns 1 in the `f_5x5` Fortran example, regardless of `options->superlu_relax` (default 30) or the `SUPERLU_RELAX` / `NREL` env vars — disabling relaxed supernodes.
- Brings the file back in line with the otherwise-identical `SRC/prec-independent/sp_ienv.c`, matching the stated intent of f972dd1f ("Make FORTRAN/sp_ienv.c compatible with the new version").

Refs #194.

## Test plan
Built `f_5x5` on macOS (Homebrew open-mpi / openblas / gfortran, ParMETIS off) and called `sp_ienv_dist(2, &options)` with default options:

| Build                                 | `options.superlu_relax` | `sp_ienv_dist(2, ...)` |
| ------------------------------------- | ----------------------- | ---------------------- |
| `SRC/prec-independent/sp_ienv.c`      | 30                      | 30 ✓                   |
| `FORTRAN/sp_ienv.c` (master)          | 30                      | 1  ✗                   |
| `FORTRAN/sp_ienv.c` (this PR)         | 30                      | 30 ✓                   |

🤖 Generated with [Claude Code](https://claude.com/claude-code)