### PR TITLE
fix compile errors with gcc-16

### DIFF
--- a/EXAMPLE/pddrive3d_block_diag_vbatch.c
+++ b/EXAMPLE/pddrive3d_block_diag_vbatch.c
@@ -21,6 +21,7 @@ at the top-level directory.
  * August 27, 2022  Add batch option
  *
  */
+#include <stdio.h>
 #include "superlu_ddefs.h"  
 
 /*! \brief
@@ -118,7 +119,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/pddrive3d_vbatch.c
+++ b/EXAMPLE/pddrive3d_vbatch.c
@@ -22,6 +22,7 @@ at the top-level directory.
  * January 7, 2024 Complete the batch interface
  *
  */
+#include <stdio.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -119,7 +120,7 @@ main (int argc, char *argv[])
     int equil,colperm, rowperm, ir, lookahead;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */


### PR DESCRIPTION
```
/home/sbalay/petsc/arch-linux-c-debug/externalpackages/git.superlu_dist/EXAMPLE/pddrive3d_vbatch.c: In function ‘main’: /home/sbalay/petsc/arch-linux-c-debug/externalpackages/git.superlu_dist/EXAMPLE/pddrive3d_vbatch.c:122:16: error: conflicting types for ‘fopen’; have ‘FILE *(void)’
  122 |     FILE *fp, *fopen ();
      |                ^~~~~
In file included from /home/sbalay/petsc/arch-linux-c-debug/externalpackages/git.superlu_dist/SRC/include/superlu_defs.h:61,
                 from /home/sbalay/petsc/arch-linux-c-debug/externalpackages/git.superlu_dist/SRC/include/superlu_ddefs.h:37,
                 from /home/sbalay/petsc/arch-linux-c-debug/externalpackages/git.superlu_dist/EXAMPLE/pddrive3d_vbatch.c:25:
/usr/include/stdio.h:271:14: note: previous declaration of ‘fopen’ with type ‘FILE *(const char * restrict,  const char * restrict)’
  271 | extern FILE *fopen (const char *__restrict __filename,
      |              ^~~~~
```