### PR TITLE
Merge master into amd_batch

### DIFF
--- a/EXAMPLE/pddrive3d_block_diag_vbatch.c
+++ b/EXAMPLE/pddrive3d_block_diag_vbatch.c
@@ -21,6 +21,7 @@ at the top-level directory.
  * August 27, 2022  Add batch option
  *
  */
+#include <stdio.h>
 #include "superlu_ddefs.h"  
 
 /*! \brief
@@ -118,7 +119,7 @@ main (int argc, char *argv[])
     int lookahead, colperm, rowperm, ir;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/EXAMPLE/pddrive3d_vbatch.c
+++ b/EXAMPLE/pddrive3d_vbatch.c
@@ -22,6 +22,7 @@ at the top-level directory.
  * January 7, 2024 Complete the batch interface
  *
  */
+#include <stdio.h>
 #include "superlu_ddefs.h"
 
 /*! \brief
@@ -119,7 +120,7 @@ main (int argc, char *argv[])
     int equil,colperm, rowperm, ir, lookahead;
     int iam, info, ldb, ldx, nrhs;
     char **cpp, c, *suffix;
-    FILE *fp, *fopen ();
+    FILE *fp;
     extern int cpp_defs ();
     int ii, omp_mpi_level, batchCount = 0;
     int*    usermap;     /* The following variables are used for batch solves */

--- a/SRC/CplusplusFactor/xlupanels.hpp
+++ b/SRC/CplusplusFactor/xlupanels.hpp
@@ -536,6 +536,13 @@ struct xLUstruct_t
             SUPERLU_FREE(A_gpu.gpuGemmBuffs);
             gpuErrchk(cudaFree((A_gpu.dgpuGemmBuffs)));
 
+            gpuErrchk(cudaFree(A_gpu.dperm_c_supno));
+
+            for (int stream = 0; stream < A_gpu.numCudaStreams; stream++) {
+                gpuErrchk(cudaStreamDestroy(A_gpu.cuStreams[stream]));
+                gpuErrchk(cudaStreamDestroy(A_gpu.lookAheadLStream[stream]));
+                gpuErrchk(cudaStreamDestroy(A_gpu.lookAheadUStream[stream]));
+            }
 
             for (int stream = 0; stream < A_gpu.numCudaStreams; stream++)
             {

--- a/SRC/complex16/zbinary_io.c
+++ b/SRC/complex16/zbinary_io.c
@@ -59,4 +59,5 @@ zwrite_binary_withname(int_t n, int_t nnz,
     printf("dump binary file ... # of doubles fwrite: %d\n", nnz_written);
     assert(nnz_written == 2*nnz);
     fclose(fp1);
+    return 0;
 }

--- a/SRC/double/dequil_vbatch.c
+++ b/SRC/double/dequil_vbatch.c
@@ -23,40 +23,45 @@ at the top-level directory.
  *
  * @param[in]      options solver options
  * @param[in]      batchCount number of matrices in the batch
- * @param[in]      m row dimension of the matrices
- * @param[in]      n column dimension of the matrices
+ * @param[in]      m pointer to the row dimensions of the matrices in the batch
+ * @param[in]      n pointer to the column dimensions of the matrices in the batch
  * @param[in, out] SparseMatrix_handles pointers to the matrices in the batch, each pointing to the actual stoage in CSC format
  *     On entry, the original matrices
  *     On exit, each matrix may be overwritten by diag(R)*A*diag(C)
  * @param[out]     ReqPtr pointers to row scaling vectors (allocated internally)
  * @param[out]     CeqPtr pointers to column scaling vectors (allocated internally)
  * @param[in, out] DiagScale arrays indicating how each system is equilibrated: {ROW, COL, BOTH}
+ * @param[in, out] info pointer to the equilibration success indicator of each system
  *
- * Return value i:
- *     = 0: successful exit
- *     > 0: indicates the first matrix in the batch has zero row or column
- *          if i <= m: the i-th row of A is exactly zero
- *          if i >  m: the (i-m)-th column of A is exactly zero
+ * Return value:
+ *     0,  success
+ *     k, indicates that the k-th matrix is the first one in the batch encountering error, can check info[k]
  * </pre>
  */
 int
 dequil_vbatch(
     superlu_dist_options_t *options, /* options for algorithm choices and algorithm parameters */
     int batchCount, /* number of matrices in the batch */
-    int *m, /* matrix row dimension */
-    int *n, /* matrix column dimension */
+    int *m, /* array of matrix row dimension, of size 'batchCount' */
+    int *n, /* array of matrix column dimension, of size 'batchCount' */
     handle_t  *SparseMatrix_handles, /* array of sparse matrix handles, of size 'batchCount',
 				      * each pointing to the actual storage
 				      */
-    double **ReqPtr, /* array of pointers to diagonal row scaling vectors,
-			each of size M   */
-    double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
-			each of size N    */
-    DiagScale_t *DiagScale /* How equilibration is done for each matrix. */
+    double **ReqPtr, /* array of pointers to diagonal row scaling vectors, of size 'batchCount',
+			size of the kth one is m[k]   */
+    double **CeqPtr, /* array of pointers to diagonal column scaling vectors, of size 'batchCount',
+			size of the kth one is n[k]    */
+    DiagScale_t *DiagScale, /* How equilibration is done for each matrix. */
     //    DeviceContext context /* device context including queues, events, dependencies */
+	int *info /* Equilibration success indicator of each system, of size 'batchCount'
+			= 0: successful exit
+			> 0: indicates the first matrix in the batch has zero row or column
+				if i <= m: the i-th row of A is exactly zero
+				if i > m: the (i-m)-th column of A is exactly zero
+			< 0: the ith place has an illegal argument */
 		  )
 {
-    int i, j, irow, icol, info = 0;
+    int i, j, irow, icol, rinfo = 0;
     fact_t Fact = options->Fact;
     int factored = (Fact == FACTORED);
     int Equil = (!factored && options->Equil == YES);
@@ -69,6 +74,7 @@ dequil_vbatch(
     SuperMatrix **A = SUPERLU_MALLOC(batchCount * sizeof(SuperMatrix *));
     for (i = 0; i < batchCount; ++i) {
 	A[i] = (SuperMatrix *) SparseMatrix_handles[i];
+	info[i] = 0;
     }
 
     /* Loop through each matrix in the batch */
@@ -157,6 +163,7 @@ dequil_vbatch(
 		/* Compute the row and column scalings. */
 
 		dgsequ_dist(A[k], R, C, &rowcnd, &colcnd, &amax, &iinfo);
+		info[k] = iinfo;
 		
 		if (iinfo > 0) {
 		    if (iinfo <= m[k]) {
@@ -168,8 +175,10 @@ dequil_vbatch(
 			fprintf(stderr, "Matrix %d: the %d-th column of A is exactly zero\n", k, (int)iinfo - n[k]);
 #endif
 		    }
-		} else if (iinfo < 0) {
-		    if ( info==0 ) info = iinfo;
+		}
+
+		if ((iinfo != 0) && (rinfo == 0)) {
+			rinfo = k+1;
 		}
 
 		/* Now iinfo == 0 */
@@ -200,5 +209,5 @@ dequil_vbatch(
 #if (DEBUGlevel >= 1)
     CHECK_MALLOC(0, "Exit dequil_batch()");
 #endif
-    return info;
+    return rinfo;
 } /* end dequil_batch */

--- a/SRC/double/dpivot_vbatch.c
+++ b/SRC/double/dpivot_vbatch.c
@@ -24,8 +24,8 @@ at the top-level directory.
  *
  * @param[in]      options solver options
  * @param[in]      batchCount number of matrices in the batch
- * @param[in]      m row dimension of the matrices
- * @param[in]      n column dimension of the matrices
+ * @param[in]      m pointer to the row dimensions of the matrices in the batch
+ * @param[in]      n pointer to the column dimensions of the matrices in the batch
  * @param[in, out] SparseMatrix_handles pointers to the matrices in the batch, each pointing to the actual stoage in CSC format
  *     On entry, the original matrices, may be overwritten by A1 <- diag(R)*A*diag(C) from dequil_batch()
  *     On exit, each matrix may be A2 <- Pr*A1
@@ -34,32 +34,35 @@ at the top-level directory.
  * @param[in,out] DiagScale array indicating how each system is equilibrated: {ROW, COL, BOTH}
  * @param[in,out] RpivPtr pointers to row permutation vectors for each matrix, each of size m
  *     On exit, each RpivPtr[] is applied to each matrix
+ * @param[in, out] info pointer to the pivoting success indicator of each system
  *
  * Return value:
  *     0,  success
  *     -1, invalid RowPerm option; an Identity perm_r[] is returned
- *     d, indicates that the d-th matrix is the first one in the batch encountering error
+ *     d, indicates that the d-th matrix is the first one in the batch encountering error, can check info[k]
  * </pre>
  */
 int
 dpivot_vbatch(
     superlu_dist_options_t *options, /* options for algorithm choices and algorithm parameters */
     int batchCount, /* number of matrices in the batch */
-    int *m, /* matrix row dimension */
-    int *n, /* matrix column dimension */
+    int *m, /* array of matrix row dimension, of size 'batchCount' */
+    int *n, /* array of matrix column dimension, of size 'batchCount' */
     handle_t  *SparseMatrix_handles, /* array of sparse matrix handles,
 				      * of size 'batchCount', each pointing to the actual storage
 				      */
-    double **ReqPtr, /* array of pointers to diagonal row scaling vectors,
-			each of size M   */
-    double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
-			each of size N    */
+    double **ReqPtr, /* array of pointers to diagonal row scaling vectors, of size 'batchCount',
+			size of the kth one is m[k]   */
+    double **CeqPtr, /* array of pointers to diagonal column scaling vectors, of size 'batchCount',
+			size of the kth one is n[k]    */
     DiagScale_t *DiagScale, /* How equilibration is done for each matrix. */
-    int **RpivPtr /* array of pointers to row permutation vectors , each of size M */
+    int **RpivPtr, /* array of pointers to row permutation vectors, of size 'batchCount',
+			size of the kth one is m[k] */
     //    DeviceContext context /* device context including queues, events, dependencies */
+	int *info /* Pivoting success indicator of each system, of size 'batchCount' */
 		  )
 {
-    int i, j, irow, iinfo, rowequ, colequ, info = 0;
+    int i, j, irow, iinfo, rowequ, colequ, rinfo = 0;
     fact_t Fact = options->Fact;
     int factored = (Fact == FACTORED);
     int Equil = (!factored && options->Equil == YES);
@@ -76,6 +79,7 @@ dpivot_vbatch(
     A = SUPERLU_MALLOC(batchCount * sizeof(SuperMatrix *));
     for (i = 0; i < batchCount; ++i) {
 	A[i] = (SuperMatrix *) SparseMatrix_handles[i];
+	info[i] = 0;
     }
 
     int_t *colptr;
@@ -141,10 +145,11 @@ dpivot_vbatch(
 			/* Finds a row permutation (serial) */
 			iinfo = dldperm_dist(job, m[d], nnz, colptr, rowind, a,
 					     perm_r, R1, C1);
+			info[d] = iinfo;
 
 			if ( iinfo ) { /* Error */
 			    printf(".. Matrix %d: LDPERM ERROR %d\n", d, iinfo);
-			    if ( info==0 ) info = d+1 ;
+			    if ( rinfo==0 ) rinfo = d+1 ;
 			}
 #if (PRNTlevel >= 2)
 			dmin = damch_dist("Overflow");
@@ -228,7 +233,8 @@ n			    if (!iam) printf("\t product of diagonal %e\n", dprod);
 #endif
 		    } else {
 			printf(".. LDPERM invalid RowPerm option %d\n", options->RowPerm);
-			info = -1;
+			rinfo = -1;
+			info[d] = -1;
 			for (i = 0; i < m[d]; ++i)	perm_r[i] = i;
 		    } /* end if-else options->RowPerm ... */
 
@@ -269,6 +275,6 @@ n			    if (!iam) printf("\t product of diagonal %e\n", dprod);
 #if (DEBUGlevel >= 1)
     CHECK_MALLOC(0, "Exit dpivot_batch()");
 #endif
-    return info;
+    return rinfo;
 
 } /* end dpivot_batch */

--- a/SRC/double/pdgssvx3d_csc_vbatch.c
+++ b/SRC/double/pdgssvx3d_csc_vbatch.c
@@ -29,21 +29,21 @@ at the top-level directory.
  * <pre>
  * @param[in]      options solver options
  * @param[in]      batchCount number of matrices in the batch
- * @param[in]      m row dimension of the matrices
- * @param[in]      n column dimension of the matrices
- * @param[in]      nnz number of non-zero entries in each matrix
+ * @param[in]      m pointer to the row dimensions of the matrices in the batch
+ * @param[in]      n pointer to the column dimensions of the matrices in the batch
+ * @param[in]      nnz pointer to the number of non-zero entries of the matrices in the batch
  * @param[in]      nrhs number of right-hand-sides
  * @param[in,out]  SparseMatrix_handles  array of sparse matrix handles, of size 'batchCount', each pointing to the actual storage in CSC format, see 'NCformat' in SuperMatix structure
  *      Each A is overwritten by row/col scaling R*A*C
  * @param[in,out]  RHSptr  array of pointers to dense storage of right-hand sides B
  *      Each B is overwritten by row/col scaling R*B*C
  * @param[in]      ldRHS array of leading dimensions of RHS
- * @param[in,out]  ReqPtr array of pointers to diagonal row scaling vectors R, each of size m
+ * @param[in,out]  ReqPtr array of pointers to diagonal row scaling vectors R, of size 'batchCount', size of the kth one is m[k],
  *    ReqPtr[] are allocated internally if equilibration is asked for
- * @param[in,out]  CeqPtr array of pointers to diagonal colum scaling vectors C, each of size n
+ * @param[in,out]  CeqPtr array of pointers to diagonal colum scaling vectors C, of size 'batchCount', size of the kth one is n[k],
  *    CeqPtr[] are allocated internally if equilibration is asked for
- * @param[in,out]  RpivPtr array of pointers to row permutation vectors, each of size m
- * @param[in,out]  CpivPtr array of pointers to column permutation vectors, each of size n
+ * @param[in,out]  RpivPtr array of pointers to row permutation vectors, of size 'batchCount', size of the kth one is m[k]
+ * @param[in,out]  CpivPtr array of pointers to column permutation vectors, of size 'batchCount', size of the kth one is n[k]
  * @param[in,out]  DiagScale array of indicators how equilibration is done for each matrix
  * @param[out]     F array of handles pointing to the factored matrices
  * @param[out]     Xptr array of pointers to dense storage of solution
@@ -69,13 +69,15 @@ pdgssvx3d_csc_vbatch(
 						  */
 		double **RHSptr, // array of pointers to dense RHS storage
 		int *ldRHS, // array of leading dimensions of RHS
-		double **ReqPtr, /* array of pointers to diagonal row scaling vectors,
-				     each of size M   */
-		double **CeqPtr, /* array of pointers to diagonal column scaling vectors,
-				    each of size N    */
-		int **RpivPtr, /* array of pointers to row permutation vectors , each of size M */
-		int **CpivPtr, /* array of pointers to column permutation vectors , each of size N */
-		DiagScale_t *DiagScale, /* indicate how equilibration is done for each matrix */
+		double **ReqPtr, /* array of pointers to diagonal row scaling vectors, size batchCount,
+				    size of the kth one is m[k]   */
+		double **CeqPtr, /* array of pointers to diagonal column scaling vectors, size batchCount,
+				    size of the kth one is n[k]    */
+		int **RpivPtr, /* array of pointers to row permutation vectors , size batchCount,
+				    size of the kth one is m[k] */
+		int **CpivPtr, /* array of pointers to column permutation vectors , size batchCount,
+				    size of the kth one is n[k] */
+		DiagScale_t *DiagScale, /* array of indicators how equilibration is done for each matrix */
 		handle_t *F, /* array of handles pointing to the factored matrices */
  		double **Xptr, // array of pointers to dense solution storage
 		int *ldX, // array of leading dimensions of X
@@ -88,7 +90,7 @@ pdgssvx3d_csc_vbatch(
 {
     /* Steps in this routine
      1. Loop through all matrices A_i, perform preprocessing (all in serial format)
-            1.1 equilibration
+        1.1 equilibration
 	    1.2 numerical pivoting (e.g., MC64)
 	    1.3 sparsity reordering
 
@@ -146,6 +148,7 @@ pdgssvx3d_csc_vbatch(
 
     int colequ, Equil, factored, job, notran, rowequ, need_value;
     int_t i, iinfo, j, k, irow;
+    int *ainfo = SUPERLU_MALLOC(batchCount * sizeof(int));
     double *C, *R; //*C1, *R1, amax, anorm, colcnd, rowcnd;
     float GA_mem_use;	/* memory usage by global A */
     float dist_mem_use; /* memory usage during distribution */
@@ -157,8 +160,8 @@ pdgssvx3d_csc_vbatch(
     /**** equilibration (LAPACK style) ****/
     /* ReqPtr[] and CeqPtr[] are allocated internally */
     /* Each A may be overwritten by R*A*C */
-    dequil_vbatch(options, batchCount, m, n, SparseMatrix_handles,
-		 ReqPtr, CeqPtr, DiagScale);
+    int eqinfo = dequil_vbatch(options, batchCount, m, n, SparseMatrix_handles,
+		ReqPtr, CeqPtr, DiagScale, ainfo);
 
     stat->utime[EQUIL] = SuperLU_timer_() - t;
     t = SuperLU_timer_();
@@ -169,8 +172,10 @@ pdgssvx3d_csc_vbatch(
      * perm_r[]'s are applied to each matrix.
      */
     /* no internal malloc */
-    dpivot_vbatch(options, batchCount, m, n, SparseMatrix_handles,
-		 ReqPtr, CeqPtr, DiagScale, RpivPtr);
+    int pvinfo = dpivot_vbatch(options, batchCount, m, n, SparseMatrix_handles,
+		 ReqPtr, CeqPtr, DiagScale, RpivPtr, ainfo);
+
+    SUPERLU_FREE(ainfo);
 
     stat->utime[ROWPERM] = SuperLU_timer_() - t;
 

--- a/SRC/double/pdgssvx3d_csc_vbatch2.c
+++ b/SRC/double/pdgssvx3d_csc_vbatch2.c
@@ -236,12 +236,13 @@ pdgssvx3d_csc_vbatch2(
     double t = SuperLU_timer_();
 
     if ( !reuse ) {
+	int *ainfo = SUPERLU_MALLOC(batchCount * sizeof(int));
 
 	/**** equilibration (LAPACK style) ****/
 	/* ReqPtr[] and CeqPtr[] are allocated internally */
 	/* Each A may be overwritten by R*A*C */
 	dequil_vbatch(options, batchCount, m, n, SparseMatrix_handles,
-		      ReqPtr, CeqPtr, DiagScale);
+		      ReqPtr, CeqPtr, DiagScale, ainfo);
 
 	stat->utime[EQUIL] = SuperLU_timer_() - t;
 	t = SuperLU_timer_();
@@ -253,7 +254,9 @@ pdgssvx3d_csc_vbatch2(
 	 */
 	/* no internal malloc */
 	dpivot_vbatch(options, batchCount, m, n, SparseMatrix_handles,
-		      ReqPtr, CeqPtr, DiagScale, RpivPtr);
+		      ReqPtr, CeqPtr, DiagScale, RpivPtr, ainfo);
+
+	SUPERLU_FREE(ainfo);
 
 	stat->utime[ROWPERM] = SuperLU_timer_() - t;
 

--- a/SRC/include/superlu_ddefs.h
+++ b/SRC/include/superlu_ddefs.h
@@ -1616,7 +1616,7 @@ extern int dequil_batch(
     );
 extern int dequil_vbatch(
     superlu_dist_options_t *, int batchCount, int *m, int *n, handle_t *,
-    double **ReqPtr, double **CeqPtr, DiagScale_t *
+    double **ReqPtr, double **CeqPtr, DiagScale_t *, int *info
     //    DeviceContext context /* device context including queues, events, dependencies */
     );
 extern int dpivot_batch(
@@ -1626,7 +1626,7 @@ extern int dpivot_batch(
     );
 extern int dpivot_vbatch(
     superlu_dist_options_t *, int batchCount, int *m, int *n, handle_t *,
-    double **ReqPtr, double **CeqPtr, DiagScale_t *, int **RpivPtr
+    double **ReqPtr, double **CeqPtr, DiagScale_t *, int **RpivPtr, int *info
     //    DeviceContext context /* device context including queues, events, dependencies */
     );
 

--- a/SRC/prec-independent/util.c
+++ b/SRC/prec-independent/util.c
@@ -302,7 +302,13 @@ void print_sp_ienv_dist(superlu_dist_options_t *options)
     }
 #endif
 
-    int gpu_enabled = get_acc_offload(options);
+#if defined(SLU_HAVE_LAPACK)
+    int gpu_trisolve_enabled = get_acc_solve();
+#else 
+    int gpu_trisolve_enabled = 0;
+#endif
+
+    int gpu_factor_enabled = get_acc_offload(options);
     
     printf("**************************************************\n");
     printf(".. blocking parameters from sp_ienv():\n");
@@ -312,7 +318,8 @@ void print_sp_ienv_dist(superlu_dist_options_t *options)
     printf("**    min GEMM m*k*n to use GPU  : %d\n", (int) sp_ienv_dist(7, options));
     printf(".. parallel environment:\n");
     printf("**    OpenMP threads             : %4d\n", num_threads);
-    printf("**    GPU enabled?               : %4d\n", gpu_enabled);
+    printf("**    GPU factor?               : %4d\n", gpu_factor_enabled);
+    printf("**    GPU trisolve?             : %4d\n", gpu_trisolve_enabled);
     printf("**************************************************\n");
 }
 


### PR DESCRIPTION
## Summary
- Merges `master` (20 commits since v9.2.1) into `amd_batch`, bringing in the variable-batched 3D solver infrastructure (`pdgssvx3d_csc_vbatch.c`, `dpivot_vbatch.c`, `dequil_vbatch.c`, `get_perm_c_vbatch.c`), GPU/NVSHMEM trisolve fixes, and HIP/ROCm and GCC-16/Fujitsu compiler portability fixes.
- Resolves one conflict in `EXAMPLE/pddrive3d_vbatch.c`, where both branches edited the same region: kept `amd_batch`'s `UseGMRES` option, the `name[100]` buffer-overflow fix, and forward-error (Ferr) reporting, combined with `master`'s `stdio.h` include and `FILE *fp` cleanup. All other files (`xlupanels.hpp`, `pdgssvx3d_csc_vbatch.c`, `superlu_ddefs.h`, `util.c`, `zbinary_io.c`, `pddrive3d_block_diag_vbatch.c`) auto-merged cleanly.

## Test plan
- [ ] Build and run the `amd_batch` test suite / examples (no MPI toolchain available in this environment to verify locally)
- [ ] Confirm `EXAMPLE/pddrive3d_vbatch.c` still builds and the `-g` (GMRES) option and Ferr reporting behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nS9L7XSUMKKDSuxNQXzs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016nS9L7XSUMKKDSuxNQXzs2)_